### PR TITLE
User config watcher

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -43,6 +43,8 @@ pub const PKG_PATH: &'static str = "hab/pkgs";
 /// be used with extreme caution.
 pub const FS_ROOT_ENVVAR: &'static str = "FS_ROOT";
 pub const SYSTEMDRIVE_ENVVAR: &'static str = "SYSTEMDRIVE";
+/// The file where user-defined configuration for each service is found.
+pub const USER_CONFIG_FILE: &'static str = "user.toml";
 
 lazy_static! {
     /// The default filesystem root path.

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -1211,6 +1211,17 @@ where
     return FileWatcher::<C, RecommendedWatcher>::create(path, callbacks);
 }
 
+pub fn default_file_watcher_with_no_initial_event<P, C>(
+    path: P,
+    callbacks: C,
+) -> Result<FileWatcher<C, RecommendedWatcher>>
+where
+    P: Into<PathBuf>,
+    C: Callbacks,
+{
+    return FileWatcher::<C, RecommendedWatcher>::create_with_no_initial_event(path, callbacks);
+}
+
 impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
     /// Creates a new `FileWatcher`.
     ///

--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -1215,12 +1215,39 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
     /// Creates a new `FileWatcher`.
     ///
     /// This will create an instance of `W` and start watching the
-    /// paths.
+    /// paths. When looping the file watcher, it will emit an initial
+    /// "file appeared" event if the watched file existed when the
+    /// file watcher was created.
     ///
     /// Will return `Error::NotifyCreateError` if creating the watcher
     /// fails. In case of watching errors, it returns
     /// `Error::NotifyError`.
     pub fn create<P>(path: P, callbacks: C) -> Result<Self>
+    where
+        P: Into<PathBuf>,
+    {
+        Self::create_instance(path, callbacks, true)
+    }
+
+    /// Creates a new `FileWatcher`.
+    ///
+    /// This will create an instance of `W` and start watching the
+    /// paths. When looping the file watcher, it will not emit any
+    /// initial "file appeared" event even the watched file existed
+    /// when the file watcher was created.
+    ///
+    /// Will return `Error::NotifyCreateError` if creating the watcher
+    /// fails. In case of watching errors, it returns
+    /// `Error::NotifyError`.
+    pub fn create_with_no_initial_event<P>(path: P, callbacks: C) -> Result<Self>
+    where
+        P: Into<PathBuf>,
+    {
+        Self::create_instance(path, callbacks, false)
+    }
+
+    // Creates an instance of the FileWatcher.
+    fn create_instance<P>(path: P, callbacks: C, send_initial_event: bool) -> Result<Self>
     where
         P: Into<PathBuf>,
     {
@@ -1241,7 +1268,11 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
                 .watch(&directory, RecursiveMode::NonRecursive)
                 .map_err(|err| sup_error!(Error::NotifyError(err)))?;
         }
-        let initial_real_file = paths.real_file.clone();
+        let initial_real_file = if send_initial_event {
+            paths.real_file.clone()
+        } else {
+            None
+        };
 
         Ok(Self {
             callbacks: callbacks,

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -524,6 +524,16 @@ impl Manager {
                 0,
             );
         }
+
+        if let Err(e) = self.user_config_watcher.add(&service) {
+            outputln!(
+                "Unable to start UserConfigWatcher for {}: {}",
+                service.spec_ident,
+                e
+            );
+            return;
+        }
+
         self.updater.add(&service);
         self.services
             .write()

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -580,6 +580,7 @@ impl Manager {
             }
             self.update_running_services_from_spec_watcher()?;
             self.update_peers_from_watch_file()?;
+            self.update_running_services_from_user_config_watcher();
             self.check_for_updated_packages();
             self.restart_elections();
             self.census_ring.update_from_rumors(
@@ -957,6 +958,17 @@ impl Manager {
                     self.butterfly.member_list.set_initial_members(members);
                 }
                 Ok(())
+            }
+        }
+    }
+
+    fn update_running_services_from_user_config_watcher(&mut self) {
+        let mut services = self.services.write().expect("Services lock is poisoned");
+
+        for service in services.iter_mut() {
+            if self.user_config_watcher.have_events_for(service) {
+                outputln!("Reloading service {}", &service.spec_ident);
+                service.user_config_updated = true;
             }
         }
     }

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -665,6 +665,7 @@ impl Manager {
         }
     }
 
+    // Creates a rumor for the specified service.
     fn gossip_latest_service_rumor(&self, service: &Service) {
         let mut incarnation = 1;
         {

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -22,6 +22,7 @@ mod service_updater;
 mod spec_watcher;
 mod file_watcher;
 mod peer_watcher;
+mod user_config_watcher;
 mod sys;
 
 use std::collections::HashMap;
@@ -59,6 +60,7 @@ use self::service::{DesiredState, Pkg, ProcessState, StartStyle};
 use self::service_updater::ServiceUpdater;
 use self::spec_watcher::{SpecWatcher, SpecWatcherEvent};
 use self::peer_watcher::PeerWatcher;
+use self::user_config_watcher::UserConfigWatcher;
 use VERSION;
 use error::{Error, Result, SupError};
 use config::GossipListenAddr;
@@ -147,6 +149,7 @@ pub struct Manager {
     services: Arc<RwLock<Vec<Service>>>,
     updater: ServiceUpdater,
     watcher: SpecWatcher,
+    user_config_watcher: UserConfigWatcher,
     organization: Option<String>,
     self_updater: Option<SelfUpdater>,
     service_states: HashMap<PackageIdent, Timespec>,
@@ -319,6 +322,7 @@ impl Manager {
             launcher: launcher,
             services: services,
             watcher: SpecWatcher::run(&fs_cfg.specs_path)?,
+            user_config_watcher: UserConfigWatcher::new(),
             fs_cfg: Arc::new(fs_cfg),
             organization: cfg.organization,
             service_states: HashMap::new(),

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -912,8 +912,8 @@ impl Manager {
 
         // The problem we're trying to work around here by adding this block is that `write`
         // creates an immutable borrow on `self`, and `self.remove_service` needs `&mut self`.
-        // The solution is to introduce the block to drop the borrow before the call to
-        // `self.remove_service`, and use `mem::swap` to copy the services to a variable defined
+        // The solution is to introduce the block to drop the immutable borrow before the call to
+        // `self.remove_service`, and use `mem::swap` to move the services to a variable defined
         // outside the block while we have the lock.
         {
             let mut services = self.services.write().expect("Services lock is poisoned!");

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -149,12 +149,12 @@ pub struct Manager {
     services: Arc<RwLock<Vec<Service>>>,
     updater: ServiceUpdater,
     spec_watcher: SpecWatcher,
+    peer_watcher: Option<PeerWatcher>,
     user_config_watcher: UserConfigWatcher,
     organization: Option<String>,
     self_updater: Option<SelfUpdater>,
     service_states: HashMap<PackageIdent, Timespec>,
     sys: Arc<Sys>,
-    peer_watcher: Option<PeerWatcher>,
 }
 
 impl Manager {
@@ -322,12 +322,12 @@ impl Manager {
             launcher: launcher,
             services: services,
             spec_watcher: SpecWatcher::run(&fs_cfg.specs_path)?,
+            peer_watcher: peer_watcher,
             user_config_watcher: UserConfigWatcher::new(),
             fs_cfg: Arc::new(fs_cfg),
             organization: cfg.organization,
             service_states: HashMap::new(),
             sys: Arc::new(sys),
-            peer_watcher: peer_watcher,
         })
     }
 

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::result;
 
 use ansi_term::Colour::Purple;
+use hcore::fs::USER_CONFIG_FILE;
 use hcore::crypto;
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
@@ -145,11 +146,16 @@ impl Cfg {
     }
 
     fn load_user(&mut self, package: &Pkg) -> Result<()> {
-        let path = package.svc_path.join("user.toml");
+        let path = package.svc_path.join(USER_CONFIG_FILE);
         let mut file = match File::open(&path) {
             Ok(file) => file,
             Err(e) => {
-                debug!("Failed to open 'user.toml', {}, {}", path.display(), e);
+                debug!(
+                    "Failed to open '{}', {}, {}",
+                    USER_CONFIG_FILE,
+                    path.display(),
+                    e
+                );
                 self.user = None;
                 return Ok(());
             }
@@ -163,7 +169,12 @@ impl Cfg {
                 self.user = Some(toml::Value::Table(toml));
             }
             Err(e) => {
-                outputln!("Failed to load 'user.toml', {}, {}", path.display(), e);
+                outputln!(
+                    "Failed to load '{}', {}, {}",
+                    USER_CONFIG_FILE,
+                    path.display(),
+                    e
+                );
                 self.user = None;
             }
         }

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -145,7 +145,7 @@ impl Cfg {
         Ok(())
     }
 
-    fn load_user(&mut self, package: &Pkg) -> Result<()> {
+    pub fn load_user(&mut self, package: &Pkg) -> Result<()> {
         let path = package.svc_path.join(USER_CONFIG_FILE);
         let mut file = match File::open(&path) {
             Ok(file) => file,

--- a/components/sup/src/manager/service/config.rs
+++ b/components/sup/src/manager/service/config.rs
@@ -74,7 +74,7 @@ impl Cfg {
     /// Updates the service configuration with data from a census group if the census group has
     /// newer data than the current configuration.
     ///
-    /// Returns true if the configuration was updated.
+    /// Returns `true` if the configuration was updated.
     pub fn update(&mut self, census_group: &CensusGroup) -> bool {
         match census_group.service_config {
             Some(ref config) => {
@@ -270,6 +270,7 @@ impl Serialize for Cfg {
 }
 
 #[derive(Debug)]
+/// Renders configuration templates into config files.
 pub struct CfgRenderer(TemplateRenderer);
 
 impl CfgRenderer {
@@ -307,6 +308,8 @@ impl CfgRenderer {
     }
 
     /// Compile and write all configuration files to the configuration directory.
+    ///
+    /// Returns `true` if the configuration has changed.
     pub fn compile(&self, pkg: &Pkg, ctx: &RenderContext) -> Result<bool> {
         // JW TODO: This function is loaded with IO errors that will be converted a Supervisor
         // error resulting in the end-user not knowing what the fuck happned at all. We need to go

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -99,6 +99,8 @@ pub trait Hook: fmt::Debug + Sized {
     fn new(service_group: &ServiceGroup, render_pair: RenderPair) -> Self;
 
     /// Compile a hook into its destination service directory.
+    ///
+    /// Returns `true` if the hook has changed.
     fn compile(&self, service_group: &ServiceGroup, ctx: &RenderContext) -> Result<bool> {
         let content = self.renderer().render(Self::file_name(), ctx)?;
         if write_hook(&content, self.path())? {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -419,6 +419,9 @@ impl Service {
         );
         let cfg_updated = self.cfg.update(census_group) || self.user_config_updated;
         if cfg_updated || census_ring.changed() {
+            if let Err(e) = self.cfg.load_user(&self.pkg) {
+                outputln!(preamble self.service_group, "Loading user-config failed: {}", e);
+            }
             let (reload, reconfigure) = {
                 let ctx = self.render_context(census_ring);
                 let reload = self.compile_hooks(&ctx);

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -288,6 +288,9 @@ impl Service {
         self.supervisor.state_entered
     }
 
+    /// Performs updates and executes hooks.
+    ///
+    /// Returns `true` if the service was updated.
     pub fn tick(&mut self, census_ring: &CensusRing, launcher: &LauncherCli) -> bool {
         if !self.initialized {
             if !self.all_binds_satisfied(census_ring) {
@@ -406,10 +409,10 @@ impl Service {
         self.supervisor.state == ProcessState::Down
     }
 
-    /// Compares the current state of the service to the current state of the census ring and
-    /// re-renders all templatable content to disk.
+    /// Compares the current state of the service to the current state of the census ring and the
+    /// user-config, and re-renders all templatable content to disk.
     ///
-    /// Returns true if any modifications were made.
+    /// Returns `true` if any modifications were made.
     fn update_templates(&mut self, census_ring: &CensusRing) -> bool {
         let census_group = census_ring.census_group_for(&self.service_group).expect(
             "Service update failed; unable to find own service group",
@@ -428,7 +431,7 @@ impl Service {
         cfg_updated
     }
 
-    /// Replace the package of the running service and restart it's system process.
+    /// Replace the package of the running service and restart its system process.
     pub fn update_package(&mut self, package: PackageInstall, launcher: &LauncherCli) {
         match Pkg::from_install(package) {
             Ok(pkg) => {
@@ -483,7 +486,7 @@ impl Service {
         rumor
     }
 
-    /// Run initialization hook if present
+    /// Run initialization hook if present.
     fn initialize(&mut self) {
         if self.initialized {
             return;
@@ -582,6 +585,8 @@ impl Service {
     }
 
     /// Helper for compiling configuration templates into configuration files.
+    ///
+    /// Returns true if the configuration has changed.
     fn compile_configuration(&self, ctx: &RenderContext) -> bool {
         match self.config_renderer.compile(&self.pkg, ctx) {
             Ok(true) => {
@@ -601,6 +606,8 @@ impl Service {
     /// Helper for compiling hook templates into hooks.
     ///
     /// This function will also perform any necessary post-compilation tasks.
+    ///
+    /// Returns `true` if any hooks have changed.
     fn compile_hooks(&self, ctx: &RenderContext) -> bool {
         let changed = self.hooks.compile(&self.service_group, ctx);
         if let Some(err) = self.copy_run().err() {
@@ -659,13 +666,14 @@ impl Service {
             if self.needs_reload || self.process_down() || self.needs_reconfiguration {
                 self.reload(launcher);
                 if self.needs_reconfiguration {
+                    // NOTE this only runs the hook if it's defined
                     self.reconfigure()
                 }
             }
         }
     }
 
-    /// Run file_updated hook if present
+    /// Run file_updated hook if present.
     fn file_updated(&self) -> bool {
         if self.initialized {
             if let Some(ref hook) = self.hooks.file_updated {
@@ -679,9 +687,9 @@ impl Service {
         false
     }
 
-    /// Write service files from gossip data to disk.
+    /// Write service files from gossip data to disk under [`svc_files_path()`](../../fs/fn.svc_files_path.html).
     ///
-    /// Returns true if a file was changed, added, or removed, and false if there were no updates.
+    /// Returns `true` if a file was changed, added, or removed, and `false` if there were no updates.
     fn update_service_files(&mut self, census_ring: &CensusRing) -> bool {
         let census_group = census_ring.census_group_for(&self.service_group).expect(
             "Service update service files failed; unable to find own service group",
@@ -742,11 +750,13 @@ impl Service {
         self.cache_health_check(check_result);
     }
 
+    // Returns `false` if the write fails.
     fn cache_service_file(&mut self, service_file: &ServiceFile) -> bool {
         let file = self.pkg.svc_files_path.join(&service_file.filename);
         self.write_cache_file(file, &service_file.body)
     }
 
+    // Returns `false` if the write fails.
     fn write_cache_file<T>(&self, file: T, contents: &[u8]) -> bool
     where
         T: AsRef<Path>,

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -422,8 +422,10 @@ impl Service {
         let something_to_do = cfg_changed || census_ring.changed();
 
         if something_to_do {
-            if let Err(e) = self.cfg.load_user(&self.pkg) {
-                outputln!(preamble self.service_group, "Loading user-config failed: {}", e);
+            if self.user_config_updated {
+                if let Err(e) = self.cfg.load_user(&self.pkg) {
+                    outputln!(preamble self.service_group, "Loading user-config failed: {}", e);
+                }
             }
 
             let (reload, reconfigure) = {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -418,35 +418,33 @@ impl Service {
             "Service update failed; unable to find own service group",
         );
         let cfg_updated_from_rumors = self.cfg.update(census_group);
-        let cfg_changed = cfg_updated_from_rumors || self.user_config_updated;
-        let something_to_do = cfg_changed || census_ring.changed();
 
-        if something_to_do {
-            if self.user_config_updated {
-                if let Err(e) = self.cfg.load_user(&self.pkg) {
-                    outputln!(preamble self.service_group, "Loading user-config failed: {}", e);
-                }
+
+        if self.user_config_updated {
+            if let Err(e) = self.cfg.load_user(&self.pkg) {
+                outputln!(preamble self.service_group, "Loading user-config failed: {}", e);
             }
-
-            let (reload, reconfigure) = {
-                let ctx = self.render_context(census_ring);
-
-                let hooks_changed = if cfg_updated_from_rumors || census_ring.changed() {
-                    self.compile_hooks(&ctx)
-                } else {
-                    false
-                };
-
-                let reconfigure = self.compile_configuration(&ctx);
-                let reload = hooks_changed || self.user_config_updated;
-
-                (reload, reconfigure)
-            };
-
-            self.needs_reload = reload;
-            self.needs_reconfiguration = reconfigure;
-            self.user_config_updated = false;
         }
+
+        let (cfg_changed, reload, reconfigure) = {
+            let ctx = self.render_context(census_ring);
+
+            if cfg_updated_from_rumors || census_ring.changed() {
+                let config_changed = cfg_updated_from_rumors || self.user_config_updated;
+                let needs_reload = self.compile_hooks(&ctx) || self.user_config_updated;
+                let needs_reconfigure = self.compile_configuration(&ctx);
+
+                (config_changed, needs_reload, needs_reconfigure)
+            } else if self.user_config_updated {
+                (true, true, self.compile_configuration(&ctx))
+            } else {
+                (false, self.needs_reload, self.needs_reconfiguration)
+            }
+        };
+
+        self.needs_reload = reload;
+        self.needs_reconfiguration = reconfigure;
+        self.user_config_updated = false;
 
         cfg_changed
     }

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -499,8 +499,7 @@ impl Service {
         }
     }
 
-    /// Run reconfigure hook if present. Return false if it is not present, to trigger default
-    /// restart behavior.
+    /// Run reconfigure hook if present.
     fn reconfigure(&mut self) {
         self.needs_reconfiguration = false;
         if let Some(ref hook) = self.hooks.reconfigure {

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -83,6 +83,7 @@ pub struct Service {
     pub pkg: Pkg,
     pub sys: Arc<Sys>,
     pub initialized: bool,
+    pub user_config_updated: bool,
 
     #[serde(skip_serializing)]
     config_renderer: CfgRenderer,
@@ -138,6 +139,7 @@ impl Service {
             last_election_status: ElectionStatus::None,
             needs_reload: false,
             needs_reconfiguration: false,
+            user_config_updated: false,
             manager_fs_cfg: manager_fs_cfg,
             supervisor: Supervisor::new(&service_group),
             pkg: pkg,

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -424,7 +424,7 @@ impl Service {
             }
             let (reload, reconfigure) = {
                 let ctx = self.render_context(census_ring);
-                let reload = self.compile_hooks(&ctx);
+                let reload = self.compile_hooks(&ctx) || self.user_config_updated;
                 let reconfigure = self.compile_configuration(&ctx);
                 (reload, reconfigure)
             };

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -417,7 +417,7 @@ impl Service {
         let census_group = census_ring.census_group_for(&self.service_group).expect(
             "Service update failed; unable to find own service group",
         );
-        let cfg_updated = self.cfg.update(census_group);
+        let cfg_updated = self.cfg.update(census_group) || self.user_config_updated;
         if cfg_updated || census_ring.changed() {
             let (reload, reconfigure) = {
                 let ctx = self.render_context(census_ring);

--- a/components/sup/src/manager/service/mod.rs
+++ b/components/sup/src/manager/service/mod.rs
@@ -427,6 +427,7 @@ impl Service {
             };
             self.needs_reload = reload;
             self.needs_reconfiguration = reconfigure;
+            self.user_config_updated = false;
         }
         cfg_updated
     }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -60,6 +60,9 @@ enum FollowerState {
     Updating(Receiver<PackageInstall>),
 }
 
+/// The ServiceUpdater is in charge of updating a Service when a more recent version of a package
+/// has been published to a depot or installed to the local package cache.
+/// To use an update strategy, the supervisor must be configured to watch a depot for new versions.
 pub struct ServiceUpdater {
     states: UpdaterStateList,
     butterfly: butterfly::Server,

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -115,7 +115,7 @@ impl UserConfigWatcher {
             let rx = &state.have_events;
 
             match rx.try_recv() {
-                Ok(()) => {
+                Ok(_) => {
                     return true;
                 }
                 Err(TryRecvError::Empty) => return false,
@@ -213,7 +213,7 @@ impl Worker {
                         }
 
                         // If we receive a message on the channel, we stop.
-                        Ok(()) => break,
+                        Ok(_) => break,
 
                         // If the channel is disconnected, we stop as well.
                         Err(TryRecvError::Disconnected) => {

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -113,7 +113,6 @@ impl UserConfigWatcher {
     /// This also consumes the events.
     pub fn have_events_for<T: Serviceable>(&self, service: &T) -> bool {
         if let Some(state) = self.states.get(service.name()) {
-
             let rx = &state.have_events;
 
             match rx.try_recv() {
@@ -122,7 +121,7 @@ impl UserConfigWatcher {
                 }
                 Err(TryRecvError::Empty) => return false,
                 Err(TryRecvError::Disconnected) => {
-                    debug!("UserConfigWatcher worker has died; restarting...");
+                    debug!("UserConfigWatcher worker has died!");
                     return false;
                 }
             }

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, sync_channel, Sender, SendError, SyncSender, Receiver, TrySendError, TryRecvError};
 use std::thread::Builder as ThreadBuilder;
 
-use super::file_watcher::{Callbacks, default_file_watcher};
+use super::file_watcher::{Callbacks, default_file_watcher_with_no_initial_event};
 
 use hcore::fs::USER_CONFIG_FILE;
 use hcore::service::ServiceGroup;
@@ -185,7 +185,7 @@ impl Worker {
                     path.display()
                 );
                 let callbacks = UserConfigCallbacks { have_events: have_events };
-                let mut file_watcher = match default_file_watcher(&path, callbacks) {
+                let mut file_watcher = match default_file_watcher_with_no_initial_event(&path, callbacks) {
                     Ok(w) => w,
                     Err(e) => {
                         outputln!(

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -98,7 +98,8 @@ impl UserConfigWatcher {
         Ok(())
     }
 
-    /// Removes a service from the User Config Watcher, thereby stopping the watcher thread.
+    /// Removes a service from the User Config Watcher, and sends a message to the watcher thread
+    /// to stop running.
     pub fn remove<T: Serviceable>(&mut self, service: &T) -> Result<(), SendError<()>> {
         if let Some(state) = self.states.remove(service.name()) {
             state.stop_running.send(())?;
@@ -107,8 +108,9 @@ impl UserConfigWatcher {
         Ok(())
     }
 
-    /// Checks whether the watcher for the specified service has observed any events, thereby
-    /// consuming them.
+    /// Checks whether the watcher for the specified service has observed any events.
+    ///
+    /// This also consumes the events.
     pub fn have_events_for<T: Serviceable>(&self, service: &T) -> bool {
         if let Some(state) = self.states.get(service.name()) {
 

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -1,0 +1,300 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{channel, Sender, Receiver, TryRecvError};
+use std::thread::Builder as ThreadBuilder;
+
+use super::file_watcher::{Callbacks, default_file_watcher};
+
+use hcore::service::ServiceGroup;
+use manager::service::Service;
+
+static LOGKEY: &'static str = "UCW";
+
+// This trait exists to ease the testing of functions that receive a Service.  Creating Services
+// requires a lot of ceremony, so we work around this with this trait.
+pub trait Serviceable {
+    fn name(&self) -> &String;
+    fn path(&self) -> &PathBuf;
+    fn service_group(&self) -> &ServiceGroup;
+}
+
+impl Serviceable for Service {
+    fn name(&self) -> &String {
+        &self.pkg.name
+    }
+
+    fn path(&self) -> &PathBuf {
+        &self.pkg.svc_path
+    }
+
+    fn service_group(&self) -> &ServiceGroup {
+        &self.service_group
+    }
+}
+
+
+// WorkerState contains the channels the worker uses to communicate with the Watcher.
+struct WorkerState {
+    // This channel is used by the watcher to be notified when a worker has events.
+    have_events: Receiver<()>,
+}
+
+type ServiceName = String;
+pub struct UserConfigWatcher {
+    states: HashMap<ServiceName, WorkerState>,
+}
+
+impl UserConfigWatcher {
+    pub fn new() -> Self {
+        Self { states: HashMap::new() }
+    }
+
+    /// Adds a service to the User Config Watcher, thereby starting a watcher thread.
+    pub fn add<T: Serviceable>(&mut self, service: &T) -> io::Result<()> {
+        // It isn't possible to use the `or_insert_with` function here because it can't have a
+        // return value, which we need to return the error from `Worker::run`.
+        if let None = self.states.get(service.name()) {
+            // Establish bi-directional communication with the worker by creating two channels.
+            let (events_tx, events_rx) = channel();
+
+            Worker::run(&service.path(), events_tx)?;
+
+            outputln!(preamble service.service_group(), "Watching user.toml");
+
+            let state = WorkerState {
+                have_events: events_rx,
+            };
+
+            self.states.insert(service.name().to_owned(), state);
+        }
+
+        Ok(())
+    }
+
+    /// Checks whether the watcher for the specified service has observed any events, thereby
+    /// consuming them.
+    pub fn have_events_for<T: Serviceable>(&self, service: &T) -> bool {
+        if let Some(state) = self.states.get(service.name()) {
+
+            let rx = &state.have_events;
+
+            match rx.try_recv() {
+                Ok(()) => {
+                    return true;
+                }
+                Err(TryRecvError::Empty) => return false,
+                Err(TryRecvError::Disconnected) => {
+                    debug!("UserConfigWatcher worker has died; restarting...");
+                    return false;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+struct UserConfigCallbacks {
+    have_events: Sender<()>,
+}
+
+impl Callbacks for UserConfigCallbacks {
+    fn file_appeared(&mut self, _: &Path) {
+        if let Err(e) = self.have_events.send(()) {
+            debug!("Worker could not notify Manager of event: {}", e);
+        }
+    }
+
+    fn file_modified(&mut self, _: &Path) {
+        if let Err(e) = self.have_events.send(()) {
+            debug!("Worker could not notify Manager of event: {}", e);
+        }
+    }
+
+    fn file_disappeared(&mut self, _: &Path) {
+        if let Err(e) = self.have_events.send(()) {
+            debug!("Worker could not notify Manager of event: {}", e);
+        }
+    }
+}
+
+struct Worker;
+
+impl Worker {
+    // starts a new thread with the file watcher tracking the service's user-config file
+    pub fn run(
+        service_path: &Path,
+        have_events: Sender<()>,
+    ) -> io::Result<()> {
+        let path = service_path.join("user.toml");
+
+        Self::setup_watcher(path, have_events)?;
+
+        Ok(())
+    }
+
+    fn setup_watcher(
+        path: PathBuf,
+        have_events: Sender<()>,
+    ) -> io::Result<()> {
+        ThreadBuilder::new()
+            .name(format!("user-config-watcher-{}", path.display()))
+            .spawn(move || {
+                debug!(
+                    "UserConfigWatcher({}) worker thread starting",
+                    path.display()
+                );
+                let callbacks = UserConfigCallbacks { have_events: have_events };
+                let mut file_watcher = match default_file_watcher(&path, callbacks) {
+                    Ok(w) => w,
+                    Err(e) => {
+                        outputln!(
+                            "UserConfigWatcher({}) could not start notifier, ending thread ({})",
+                            path.display(),
+                            e
+                        );
+                        return;
+                    }
+                };
+
+
+                if let Err(e) = file_watcher.run() {
+                    outputln!(
+                        "UserConfigWatcher({}) could not run notifier, ending thread ({})",
+                        path.display(),
+                        e
+                    );
+                    return;
+                };
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::{remove_file, File};
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use tempdir::TempDir;
+
+    #[test]
+    fn no_events_at_first() {
+        let service = TestService::default();
+        let mut ucm = UserConfigWatcher::new();
+        ucm.add(&service).expect("adding service");
+
+        assert!(!ucm.have_events_for(&service));
+    }
+
+    #[test]
+    fn events_present_after_adding_config() {
+        let service = TestService::default();
+        let mut ucm = UserConfigWatcher::new();
+        ucm.add(&service).expect("adding service");
+
+        File::create(service.path().join("user.toml")).expect("creating file");
+
+        assert!(wait_for_events(&ucm, &service));
+    }
+
+    #[test]
+    fn events_present_after_changing_config() {
+        let service = TestService::default();
+        let file_path = service.path().join("user.toml");
+        let mut ucm = UserConfigWatcher::new();
+
+        ucm.add(&service).expect("adding service");
+        let mut file = File::create(&file_path).expect("creating file");
+
+        file.write_all(b"42").expect("writing to user.toml");
+
+        assert!(wait_for_events(&ucm, &service));
+    }
+
+    #[test]
+    fn events_present_after_removing_config() {
+        let service = TestService::default();
+        let file_path = service.path().join("user.toml");
+        let mut ucm = UserConfigWatcher::new();
+
+        ucm.add(&service).expect("adding service");
+        File::create(&file_path).expect("creating file");
+
+        // Allow the watcher to notice that a file was created.
+        thread::sleep(Duration::from_millis(100));
+
+        remove_file(&file_path).expect("removing file");
+
+        assert!(wait_for_events(&ucm, &service));
+    }
+
+    fn wait_for_events<T: Serviceable>(ucm: &UserConfigWatcher, service: &T) -> bool {
+        let start = Instant::now();
+        let timeout = Duration::from_millis(1000);
+
+        while start.elapsed() < timeout {
+            if ucm.have_events_for(service) {
+                return true;
+            }
+
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        false
+    }
+
+    struct TestService {
+        name: String,
+        path: PathBuf,
+        service_group: ServiceGroup,
+    }
+
+    impl Serviceable for TestService {
+        fn name(&self) -> &String {
+            &self.name
+        }
+
+        fn path(&self) -> &PathBuf {
+            &self.path
+        }
+
+        fn service_group(&self) -> &ServiceGroup {
+            &self.service_group
+        }
+    }
+
+    impl Default for TestService {
+        fn default() -> Self {
+            Self {
+                name: String::from("foo"),
+                path: TempDir::new("user-config-watcher")
+                    .expect("creating temp dir")
+                    .into_path(),
+                service_group: ServiceGroup::from_str("foo.bar@yoyodine").unwrap(),
+            }
+        }
+    }
+}

--- a/components/sup/src/manager/user_config_watcher.rs
+++ b/components/sup/src/manager/user_config_watcher.rs
@@ -136,18 +136,20 @@ struct UserConfigCallbacks {
 
 impl Callbacks for UserConfigCallbacks {
     fn file_appeared(&mut self, _: &Path) {
-        if let Err(TrySendError::Disconnected(_)) = self.have_events.try_send(()) {
-            debug!("Worker could not notify Manager of event");
-        }
+        self.perform();
     }
 
     fn file_modified(&mut self, _: &Path) {
-        if let Err(TrySendError::Disconnected(_)) = self.have_events.try_send(()) {
-            debug!("Worker could not notify Manager of event");
-        }
+        self.perform();
     }
 
     fn file_disappeared(&mut self, _: &Path) {
+        self.perform();
+    }
+}
+
+impl UserConfigCallbacks {
+    fn perform(&self) {
         if let Err(TrySendError::Disconnected(_)) = self.have_events.try_send(()) {
             debug!("Worker could not notify Manager of event");
         }

--- a/www/source/partials/docs/_reference-hooks.html.md.erb
+++ b/www/source/partials/docs/_reference-hooks.html.md.erb
@@ -72,7 +72,7 @@ For processes that can update their configuration without requiring a restart a 
 ###reconfigure
 File location: `<plan>/hooks/reconfigure`
 
-This hook is run when service configuration information has changed through a set of Habitat services that are peers with each other. Before the `reconfigure` hook the config files are re-rendered and the process is either restarted or the `reload` hook is called if present.
+This hook is run when service configuration has changed due to updates coming from the gossip protocol or from the `user.toml` file. Before the `reconfigure` hook the config files are re-rendered and the process is either restarted or the `reload` hook is called if present.
 
 ###suitability
 File location: `<plan>/hooks/suitability`

--- a/www/source/partials/docs/_reference-supervisor-log-keys.html.md.erb
+++ b/www/source/partials/docs/_reference-supervisor-log-keys.html.md.erb
@@ -41,5 +41,6 @@ The meanings of the keys are as follows:
 | SU | Service updater |
 | SV | Supervisor |
 | SY | "sys" utility |
+| UCW | User-config watcher |
 | UR | Users utility |
 | UT | Utilities |


### PR DESCRIPTION
This PR adds a watcher for the `user.toml` file.

It's based on @krnowak's still-unmerged work on the file watcher.