### PR TITLE
Add initial_file_event arg to FileWatcher::run

### DIFF
--- a/components/sup/src/manager/file_watcher.rs
+++ b/components/sup/src/manager/file_watcher.rs
@@ -1293,17 +1293,29 @@ impl<C: Callbacks, W: Watcher> FileWatcher<C, W> {
         }
     }
 
-    pub fn run(&mut self) -> Result<()> {
+    /// Runs the FileWatcher in a loop.
+    ///
+    /// The `initial_file_event` parameter controls whether an event is emitted when the file was
+    /// already there at the time the FileWatcher was started.
+    pub fn run(&mut self, initial_file_event: bool) -> Result<()> {
         loop {
-            self.single_iteration()?;
+            self.single_iteration(initial_file_event)?;
         }
     }
 
-    pub fn single_iteration(&mut self) -> Result<()> {
-        if let Some(ref real_file) = self.initial_real_file {
-            self.callbacks.file_appeared(real_file);
+    /// Receives an event from the file watcher, without blocking.
+    ///
+    /// The `initial_file_event` parameter controls whether an event is emitted when the file was
+    /// already there at the time the FileWatcher was started.
+    pub fn single_iteration(&mut self, initial_file_event: bool) -> Result<()> {
+        if initial_file_event {
+            if let Some(ref real_file) = self.initial_real_file {
+                self.callbacks.file_appeared(real_file);
+            }
         }
+
         self.initial_real_file = None;
+
         self.rx
             .recv()
             .map_err(|e| sup_error!(Error::RecvError(e)))

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -108,7 +108,7 @@ impl PeerWatcher {
                 }
             }
         };
-        if let Err(err) = file_watcher.run() {
+        if let Err(err) = file_watcher.run(true) {
             outputln!(
                 "PeerWatcher({}) error during watching ({}), restarting",
                 path.display(),


### PR DESCRIPTION
The additional parameter serves to control whether an event should be
emitted if, at the time the FileWatcher starts, the watched file is
already present.

In the case of the PeerWatcher, this is exactly the behaviour we want,
because in Kubernetes, when a pod starts its volumes (and the peer file
among them) have already been mounted.

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>