### PR TITLE
[WIP] BLDR setup: Remove hardcoded github credentials

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,11 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "~/.hab/etc", "/hab/etc"
 
   config.vm.network "forwarded_port", guest: 80, host: 9636
-  config.vm.network "forwarded_port", guest: 9631, host: 9631
-  config.vm.network "forwarded_port", guest: 9636, host: 9636
+  config.vm.network "forwarded_port", guest: 9631, host: 9631 # http-gateway
+  config.vm.network "forwarded_port", guest: 9636, host: 9636 # bldr-api
+  config.vm.network "forwarded_port", guest: 3000, host: 3000 # bldr-web (local)
+  config.vm.network "forwarded_port", guest: 3001, host: 3001 # bldr-web (ui)
+  config.vm.network "forwarded_port", guest: 6443, host: 6443 # kube-apiserver
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 4096

--- a/components/builder-web/app/package/package-builds/package-builds.component.ts
+++ b/components/builder-web/app/package/package-builds/package-builds.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 
 @Component({

--- a/components/builder-web/app/package/package-readme/package-readme.component.ts
+++ b/components/builder-web/app/package/package-readme/package-readme.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 
 @Component({
   template: require('./package-readme.component.html')

--- a/components/builder-web/app/package/package-release/package-release.component.ts
+++ b/components/builder-web/app/package/package-release/package-release.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 import { fetchPackage } from '../../actions/index';
 

--- a/components/builder-web/app/package/package-settings/package-settings.component.ts
+++ b/components/builder-web/app/package/package-settings/package-settings.component.ts
@@ -15,7 +15,7 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 
 @Component({

--- a/components/builder-web/app/package/package-versions/package-versions.component.ts
+++ b/components/builder-web/app/package/package-versions/package-versions.component.ts
@@ -14,7 +14,7 @@
 
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/subscription';
+import { Subscription } from 'rxjs/Subscription';
 import { AppStore } from '../../app.store';
 import { packageString, releaseToDate } from '../../util';
 import { fetchPackageVersions, filterPackagesBy } from '../../actions/index';

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -4,6 +4,16 @@ Vagrant setup
 ## Prerequisites
 
 - Get the secrets from https://gist.github.com/indradhanush/184f19d26ff96ff537e336dd13c63c64 and place them under `$PROJECT_ROOT/.secrets/`
+- You need to update `components/builder-web/habitat.conf.js` to include the following lines:
+
+```
+    github_client_id: "Iv1.62694049addd0336",
+    github_app_id: "6930",
+```
+
+- You need to set up the "User authorization callback URL" to
+  `http://localhost:3000/sign-in`. on
+  [Github apps](https://github.com/settings/apps).
 
 ## One step
 

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -35,6 +35,10 @@ to avoid errors like `401 unauthorized`.
 * user:email
 * read:org
 
+Please make sure that the system clock is set correctly, e.g. by running ntpd.
+When the time is drifted a lot, github could reject requests so that hab-bldr
+cannot continue to do anything at all.
+
 ## Setup
 
 From project root run:
@@ -99,3 +103,9 @@ cp /hab/cache/keys/foo-20171103084851.* /home/krangschnak/.hab/cache/keys/
 
 * Logs are very verbose by default. Remove `RUST_LOG=debug,` from
   `support/bldr.env` to suppress `DEBUG` logs.
+* In the bldr log, please ignore messages like below. This message shows up
+  no matter whether the authentication succeeded or not:
+
+```
+sessionsrv.1 | WARN:habitat_builder_sessionsrv::server::handlers: Failed to obtain installation token, GitHub App Authentication error, message=Not Found, documentation_url=https://developer.github.com/v3/apps/#create-a-new-installation-token
+```

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -1,56 +1,53 @@
-Vagrant setup
-===
+# Vagrant setup
 
 ## Prerequisites
 
-- Get the secrets from https://gist.github.com/indradhanush/184f19d26ff96ff537e336dd13c63c64 and place them under `$PROJECT_ROOT/.secrets/`
-- You need to update `components/builder-web/habitat.conf.js` to include the following lines:
+Get the secrets from Michael (private URL) and place them under
+`$PROJECT_ROOT/.secrets/`. You should have two files there:
 
 ```
-    github_client_id: "Iv1.62694049addd0336",
-    github_app_id: "6930",
+ls .secrets/
+builder-github-app.pem  habitat-env
 ```
 
-- You need to set up the "User authorization callback URL" to
-  `http://localhost:3000/sign-in`. on
-  [Github apps](https://github.com/settings/apps).
+You need to update `components/builder-web/habitat.conf.sample.js` with the
+`github_client_id` and `github_app_id` from the `.secrets/habitat-env` file
+above.
 
-## One step
+To avoid a cached "bad" `habitat.conf.js` file, delete it:
 
-This is fragile. Recommended to go manual at the moment.
-`./scripts/vagrant/setup.sh`
+```
+rm components/builder-web/habitat.conf.js
+```
 
-## Manual
+## Setup
 
 From project root run:
 
-`vagrant destroy -f && vagrant up && vagrant ssh`
-
-### Inside vagrant:
-
 ```
-hab origin key generate <your-origin-name>
-sudo su -
-direnv allow
-cd /src
-make build-bin build-srv
-```
-
-## Running bldr
-
-```
+vagrant destroy -f
+vagrant up
 vagrant ssh
+```
+
+Then, in the VM:
+
+```
 sudo su -
+tmux # if you want :)
 cd /src
-direnv allow
+direnv allow .
+make build-bin build-srv
+[...]
 make bldr-run-no-build
 ```
 
-## Testing the setup
-
-Try running the http examples shown in [BUILDER_DEV.md](../../BUILDER_DEV.md)
+Now go to http://localhost:3000/#/pkgs and click Sign-in. You should be
+redirected to GitHub and asked if you allow the `habitat-dev-local`
+GitHub app. You should be redirected to Habitat Builder (i.e. localhost:3000)
+and be logged-in.
 
 ## Troubleshooting
 
-- Logs are very verbose by default. Remove `RUST_LOG=debug,` from `support/bldr.env` to suppress `DEBUG` logs.
-- Please make sure that the web interface daemon `lite-server` is running. If not, try to run `support/builder_web.sh`
+* Logs are very verbose by default. Remove `RUST_LOG=debug,` from
+  `support/bldr.env` to suppress `DEBUG` logs.

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -3,30 +3,7 @@ Vagrant setup
 
 ## Prerequisites
 
-- [Create a Github app](https://github.com/settings/apps) and download the private key from the app's page.
-- Put it under `$PROJECT_ROOT/.secrets/builder-github-app.pem`
-- Create a new file at `$PROJECT_ROOT/.secrets/habitat-env` and write the following into it:
-
-```
-export APP_HOSTNAME=localhost:3000
-
-export GITHUB_API_URL=https://api.github.com
-export GITHUB_WEB_URL=https://github.com
-
-export GITHUB_APP_ID=""
-
-export GITHUB_CLIENT_ID=""
-export GITHUB_CLIENT_SECRET=""
-
-export WORKER_AUTH_TOKEN=""
-
-export GITHUB_ADMIN_TEAM=""
-export GITHUB_WORKER_TEAM=""
-
-export GITHUB_WEBHOOK_SECRET=""
-```
-
-- Ask a cowrecker for secrets (easy). Or generate your own (painful).
+- Get the secrets from https://gist.github.com/indradhanush/184f19d26ff96ff537e336dd13c63c64 and place them under `$PROJECT_ROOT/.secrets/`
 
 ## One step
 

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -62,6 +62,33 @@ redirected to GitHub and asked if you allow the `habitat-dev-local`
 GitHub app. You should be redirected to Habitat Builder (i.e. localhost:3000)
 and be logged-in.
 
+You should now be able to connect a plan from GitHub.
+
+## Building a package
+
+To be able to build a package, your Vagrant instance needs to provide the
+required `core/...` packages.
+
+First, create an origin `core` for that.
+
+Second, for each required package, download it from upstream Habitat Builder
+(or build it yourself, if necessary) and upload the package to your local
+instance. Example for `core/hab-backline`, which is always needed:
+
+```
+test -z "$HAB_ORIGIN" || echo "\$HAB_BLDR_URL is set, unset if first"
+hab pkg install core/hab-backline
+# `load_package` is a helper function that should be available
+# in your vagrant box. You can check with `type load_package`.
+load_package /hab/cache/artifacts/core-hab-backline-0.40.0-20171128175957-x86_64-linux.hart
+# ... The package + all dependencies will be uploaded to your *local*
+# core origin
+```
+
+Now, trigger a new build. For a package with no dependencies, above should
+be enough. Otherwise, repeat the process for every package reported
+missing during the build.
+
 ## Troubleshooting
 
 * Logs are very verbose by default. Remove `RUST_LOG=debug,` from

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -76,7 +76,7 @@ Second, for each required package, download it from upstream Habitat Builder
 instance. Example for `core/hab-backline`, which is always needed:
 
 ```
-test -z "$HAB_ORIGIN" || echo "\$HAB_BLDR_URL is set, unset if first"
+test -z "$HAB_ORIGIN" || echo "\$HAB_BLDR_URL is set, unset it first"
 hab pkg install core/hab-backline
 # `load_package` is a helper function that should be available
 # in your vagrant box. You can check with `type load_package`.
@@ -88,6 +88,14 @@ load_package /hab/cache/artifacts/core-hab-backline-0.40.0-20171128175957-x86_64
 Now, trigger a new build. For a package with no dependencies, above should
 be enough. Otherwise, repeat the process for every package reported
 missing during the build.
+
+If the build fails due to a missing public key, make sure you have both
+a public and a private key in the `/home/krangschnak/.hab/cache/keys/`
+directory, e.g.
+
+```
+cp /hab/cache/keys/foo-20171103084851.* /home/krangschnak/.hab/cache/keys/
+```
 
 ## Troubleshooting
 

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -66,3 +66,4 @@ Try running the http examples shown in [BUILDER_DEV.md](../../BUILDER_DEV.md)
 ## Troubleshooting
 
 - Logs are very verbose by default. Remove `RUST_LOG=debug,` from `support/bldr.env` to suppress `DEBUG` logs.
+- Please make sure that the web interface daemon `lite-server` is running. If not, try to run `support/builder_web.sh`

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -96,6 +96,7 @@ a public and a private key in the `/home/krangschnak/.hab/cache/keys/`
 directory, e.g.
 
 ```
+mkdir --parent /home/krangschnak/.hab/cache/keys
 cp /hab/cache/keys/foo-20171103084851.* /home/krangschnak/.hab/cache/keys/
 ```
 

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -1,0 +1,68 @@
+Vagrant setup
+===
+
+## Prerequisites
+
+- [Create a Github app](https://github.com/settings/apps) and download the private key from the app's page.
+- Put it under `$PROJECT_ROOT/.secrets/builder-github-app.pem`
+- Create a new file at `$PROJECT_ROOT/.secrets/habitat-env` and write the following into it:
+
+```
+export APP_HOSTNAME=localhost:3000
+
+export GITHUB_API_URL=https://api.github.com
+export GITHUB_WEB_URL=https://github.com
+
+export GITHUB_APP_ID=""
+
+export GITHUB_CLIENT_ID=""
+export GITHUB_CLIENT_SECRET=""
+
+export WORKER_AUTH_TOKEN=""
+
+export GITHUB_ADMIN_TEAM=""
+export GITHUB_WORKER_TEAM=""
+
+export GITHUB_WEBHOOK_SECRET=""
+```
+
+- Ask a cowrecker for secrets (easy). Or generate your own (painful).
+
+## One step
+
+This is fragile. Recommended to go manual at the moment.
+`./scripts/vagrant/setup.sh`
+
+## Manual
+
+From project root run:
+
+`vagrant destroy -f && vagrant up && vagrant ssh`
+
+### Inside vagrant:
+
+```
+hab origin key generate <your-origin-name>
+sudo su -
+direnv allow
+cd /src
+make build-bin build-srv
+```
+
+## Running bldr
+
+```
+vagrant ssh
+sudo su -
+cd /src
+direnv allow
+make bldr-run-no-build
+```
+
+## Testing the setup
+
+Try running the http examples shown in [BUILDER_DEV.md](../../BUILDER_DEV.md)
+
+## Troubleshooting
+
+- Logs are very verbose by default. Remove `RUST_LOG=debug,` from `support/bldr.env` to suppress `DEBUG` logs.

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -21,6 +21,20 @@ To avoid a cached "bad" `habitat.conf.js` file, delete it:
 rm components/builder-web/habitat.conf.js
 ```
 
+Set the following env variables:
+
+```
+export HAB_AUTH_TOKEN=<your github auth token>
+export HAB_ORIGIN=<your origin>
+```
+
+The two variables can be different for each user.
+Make sure that your github auth token has the following permissions,
+to avoid errors like `401 unauthorized`.
+
+* user:email
+* read:org
+
 ## Setup
 
 From project root run:

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -12,7 +12,8 @@ builder-github-app.pem  habitat-env
 
 You need to update `components/builder-web/habitat.conf.sample.js` with the
 `github_client_id` and `github_app_id` from the `.secrets/habitat-env` file
-above.
+above. You also need to set the `github_app_url` to
+`https://github.com/apps/habitat-dev-local`.
 
 To avoid a cached "bad" `habitat.conf.js` file, delete it:
 

--- a/scripts/vagrant/README.md
+++ b/scripts/vagrant/README.md
@@ -76,11 +76,9 @@ Second, for each required package, download it from upstream Habitat Builder
 instance. Example for `core/hab-backline`, which is always needed:
 
 ```
-test -z "$HAB_ORIGIN" || echo "\$HAB_BLDR_URL is set, unset it first"
+test -z "$HAB_BLDR_URL" || echo "\$HAB_BLDR_URL is set, unset it first"
 hab pkg install core/hab-backline
-# `load_package` is a helper function that should be available
-# in your vagrant box. You can check with `type load_package`.
-load_package /hab/cache/artifacts/core-hab-backline-0.40.0-20171128175957-x86_64-linux.hart
+hab pkg upload --url http://localhost:9636/v1 --auth "${HAB_AUTH_TOKEN}" "/hab/cache/artifacts/core-hab-backline-0.40.0-20171128175957-x86_64-linux.hart" --channel stable
 # ... The package + all dependencies will be uploaded to your *local*
 # core origin
 ```

--- a/scripts/vagrant/setup.sh
+++ b/scripts/vagrant/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo pipefail
+
+vagrant destroy -f
+
+vagrant up
+
+vagrant ssh -c "sudo su - && cd /src && direnv allow && make build-bin build-srv"
+

--- a/support/Procfile
+++ b/support/Procfile
@@ -1,3 +1,4 @@
+web: support/builder_web.sh
 postgres: hab svc start core/builder-datastore
 api: /src/target/debug/bldr-api start --config /hab/svc/builder-api/user.toml
 admin: /src/target/debug/bldr-admin start

--- a/support/builder/config.sh
+++ b/support/builder/config.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 export PGPASSWORD
 PGPASSWORD=$(cat /hab/svc/builder-datastore/config/pwfile)
 
@@ -12,7 +14,7 @@ url = "$GITHUB_API_URL"
 web_url = "$GITHUB_WEB_URL"
 client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
-app_id = 5629
+app_id = $GITHUB_APP_ID
 
 [web]
 app_url          = "http://$APP_HOSTNAME"
@@ -37,7 +39,7 @@ url = "$GITHUB_API_URL"
 web_url = "$GITHUB_WEB_URL"
 client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
-app_id = 5629
+app_id = $GITHUB_APP_ID
 EOT
 
 mkdir -p /hab/svc/builder-jobsrv
@@ -339,7 +341,7 @@ early_access_teams = [$GITHUB_ADMIN_TEAM]
 url = "$GITHUB_API_URL"
 client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
-app_id = 5629
+app_id = $GITHUB_APP_ID
 EOT
 
 mkdir -p /hab/svc/builder-worker
@@ -356,5 +358,5 @@ url = "$GITHUB_API_URL"
 web_url = "$GITHUB_WEB_URL"
 client_id = "$GITHUB_CLIENT_ID"
 client_secret = "$GITHUB_CLIENT_SECRET"
-app_id = 5629
+app_id = $GITHUB_APP_ID
 EOT

--- a/support/linux/provision.sh
+++ b/support/linux/provision.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-export APP_HOSTNAME=localhost:3000
-export GITHUB_API_URL=https://api.github.com
-export GITHUB_WEB_URL=https://github.com
-export GITHUB_CLIENT_ID=Iv1.732260b62f84db15
-export GITHUB_CLIENT_SECRET=fc7654ed8c65ccfe014cd339a55e3538f935027a
-export WORKER_AUTH_TOKEN=fc7654ed8c65ccfe014cd339a55e3538f935027a
-export GITHUB_ADMIN_TEAM=1995301
-export GITHUB_WORKER_TEAM=2555389
-export GITHUB_WEBHOOK_SECRET=58d4afaf5e5617ab0f8c39e505605e78a054d003
+ENV_CONFIG="/src/.secrets/habitat-env"
+
+if [[ -f $ENV_CONFIG ]]; then
+    source $ENV_CONFIG
+else
+    export APP_HOSTNAME=localhost:3000
+    export GITHUB_API_URL=https://api.github.com
+    export GITHUB_WEB_URL=https://github.com
+    export GITHUB_APP_ID=5629
+    export GITHUB_CLIENT_ID=Iv1.732260b62f84db15
+    export GITHUB_CLIENT_SECRET=fc7654ed8c65ccfe014cd339a55e3538f935027a
+    export WORKER_AUTH_TOKEN=fc7654ed8c65ccfe014cd339a55e3538f935027a
+    export GITHUB_ADMIN_TEAM=1995301
+    export GITHUB_WORKER_TEAM=2555389
+    export GITHUB_WEBHOOK_SECRET=58d4afaf5e5617ab0f8c39e505605e78a054d003
+fi
 
 pushd /src
 cp components/hab/install.sh /tmp/


### PR DESCRIPTION
This commit adds an option to create a new file under
`$PROJECT_ROOT/src/.secrets/habitat-env` that can store custom github
keys and secrets. If this file is not present it defaults to the
current behaviour of using the hardcoded keys.

The changes affect the Vagrant setup and this also includes
instructions for setting up BLDR under Vagrant.