### PR TITLE
[WIP] builder-worker: kubernetes exporter integration

### DIFF
--- a/components/builder-worker/build.rs
+++ b/components/builder-worker/build.rs
@@ -9,6 +9,7 @@ fn main() {
     write_docker_exporter_pkg_ident();
     write_docker_pkg_ident();
     write_kubernetes_exporter_pkg_ident();
+    write_kubectl_pkg_ident();
 }
 
 fn write_studio_pkg_ident() {
@@ -49,4 +50,14 @@ fn write_kubernetes_exporter_pkg_ident() {
         _ => String::from("core/hab-pkg-export-kubernetes"),
     };
     util::write_out_dir_file("KUBERNETES_EXPORTER_PKG_IDENT", ident);
+}
+
+fn write_kubectl_pkg_ident() {
+    let ident = match env::var("PLAN_KUBECTL_PKG_IDENT") {
+        // Use the value provided by the build system if present
+        Ok(ident) => ident,
+        // Use the latest installed package as a default for development
+        _ => String::from("core/kubectl"),
+    };
+    util::write_out_dir_file("KUBECTL_PKG_IDENT", ident);
 }

--- a/components/builder-worker/build.rs
+++ b/components/builder-worker/build.rs
@@ -8,6 +8,7 @@ fn main() {
     write_studio_pkg_ident();
     write_docker_exporter_pkg_ident();
     write_docker_pkg_ident();
+    write_kubernetes_exporter_pkg_ident();
 }
 
 fn write_studio_pkg_ident() {
@@ -38,4 +39,14 @@ fn write_docker_pkg_ident() {
         _ => String::from("core/docker"),
     };
     util::write_out_dir_file("DOCKER_PKG_IDENT", ident);
+}
+
+fn write_kubernetes_exporter_pkg_ident() {
+    let ident = match env::var("PLAN_KUBERNETES_EXPORTER_PKG_IDENT") {
+        // Use the value provided by the build system if present
+        Ok(ident) => ident,
+        // Use the latest installed package as a default for development
+        _ => String::from("core/hab-pkg-export-kubernetes"),
+    };
+    util::write_out_dir_file("KUBERNETES_EXPORTER_PKG_IDENT", ident);
 }

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -42,4 +42,9 @@ do_prepare() {
   PLAN_KUBERNETES_EXPORTER_PKG_IDENT=$(pkg_path_for hab-pkg-export-kubernetes | sed "s,^$HAB_PKG_PATH/,,")
   export PLAN_KUBERNETES_EXPORTER_PKG_IDENT
   build_line "Setting PLAN_KUBERNETES_EXPORTER_PKG_IDENT=$PLAN_KUBERNETES_EXPORTER_PKG_IDENT"
+
+  # Compile the fully-qualified Kubernetes package identifier into the binary
+  PLAN_KUBECTL_PKG_IDENT=$(pkg_path_for kubernetes | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_KUBECTL_PKG_IDENT
+  build_line "Setting PLAN_KUBECTL_PKG_IDENT=$PLAN_KUBECTL_PKG_IDENT"
 }

--- a/components/builder-worker/habitat/plan.sh
+++ b/components/builder-worker/habitat/plan.sh
@@ -37,4 +37,9 @@ do_prepare() {
   PLAN_DOCKER_PKG_IDENT=$(pkg_path_for docker | sed "s,^$HAB_PKG_PATH/,,")
   export PLAN_DOCKER_PKG_IDENT
   build_line "Setting PLAN_DOCKER_PKG_IDENT=$PLAN_DOCKER_PKG_IDENT"
+
+  # Compile the fully-qualified Kubernetes exporter package identifier into the binary
+  PLAN_KUBERNETES_EXPORTER_PKG_IDENT=$(pkg_path_for hab-pkg-export-kubernetes | sed "s,^$HAB_PKG_PATH/,,")
+  export PLAN_KUBERNETES_EXPORTER_PKG_IDENT
+  build_line "Setting PLAN_KUBERNETES_EXPORTER_PKG_IDENT=$PLAN_KUBERNETES_EXPORTER_PKG_IDENT"
 }

--- a/components/builder-worker/src/error.rs
+++ b/components/builder-worker/src/error.rs
@@ -49,6 +49,7 @@ pub enum Error {
     GithubAppAuthErr(github_api_client::HubError),
     HabitatCore(hab_core::Error),
     InvalidIntegrations(String),
+    Kubectl(io::Error),
     NoAuthTokenError,
     NoNetworkGatewayError,
     NoNetworkInterfaceError,
@@ -110,6 +111,7 @@ impl fmt::Display for Error {
             Error::GithubAppAuthErr(ref e) => format!("{}", e),
             Error::HabitatCore(ref e) => format!("{}", e),
             Error::InvalidIntegrations(ref s) => format!("Invalid integration: {}", s),
+            Error::Kubectl(ref e) => format!("Failure running kubectl, {}", e),
             Error::NoAuthTokenError => format!("No auth_token config specified"),
             Error::NoNetworkGatewayError => format!("No network_gateway config specified"),
             Error::NoNetworkInterfaceError => format!("No network_interface config specified"),
@@ -173,6 +175,7 @@ impl error::Error for Error {
             Error::GithubAppAuthErr(ref err) => err.description(),
             Error::HabitatCore(ref err) => err.description(),
             Error::InvalidIntegrations(_) => "Invalid integrations detected",
+            Error::Kubectl(ref err) => err.description(),
             Error::NoAuthTokenError => "No auth_token config specified",
             Error::NoNetworkGatewayError => "No network_gateway config specified",
             Error::NoNetworkInterfaceError => "No network_interface config specified",
@@ -221,5 +224,11 @@ impl From<protocol::ProtocolError> for Error {
 impl From<zmq::Error> for Error {
     fn from(err: zmq::Error) -> Error {
         Error::Zmq(err)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::Kubectl(err)
     }
 }

--- a/components/builder-worker/src/runner/kubernetes.rs
+++ b/components/builder-worker/src/runner/kubernetes.rs
@@ -45,12 +45,9 @@ pub struct KubernetesExporter<'a> {
 
 impl<'a> KubernetesExporter<'a> {
     /// Creates a new Kubernetes exporter for a given `Workspace` and Builder URL.
-    pub fn new(workspace: &'a Workspace, bldr_url: &'a str) -> Self {
+    pub fn new(spec: KubernetesExporterSpec, workspace: &'a Workspace, bldr_url: &'a str) -> Self {
         KubernetesExporter {
-            spec: KubernetesExporterSpec {
-                kubeconfig: String::from("/opt/kubeconfig"),
-                replicas: 1,
-            },
+            spec: spec,
             workspace: workspace,
             bldr_url: bldr_url,
         }

--- a/components/builder-worker/src/runner/kubernetes.rs
+++ b/components/builder-worker/src/runner/kubernetes.rs
@@ -36,7 +36,7 @@ const KUBECONFIG_ENVVAR: &'static str = "KUBECONFIG";
 
 pub struct KubernetesExporterSpec {
     pub kubeconfig_path: String,
-    pub replicas: i32,
+    pub replicas: i64,
 }
 
 pub struct KubernetesExporter<'a> {

--- a/components/builder-worker/src/runner/kubernetes.rs
+++ b/components/builder-worker/src/runner/kubernetes.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 use std::process::{Child, Command, ExitStatus, Stdio};
@@ -125,7 +126,9 @@ impl<'a> KubernetesExporter<'a> {
 
         cmd.stdin(exporter.stdout.unwrap());
         cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
+        cmd.stderr(Stdio::from(File::create(
+            self.workspace.root().join("kubectl.stderr.log"),
+        )?));
 
         debug!("spawning kubectl command");
         let mut child = cmd.spawn().map_err(Error::Exporter)?;

--- a/components/builder-worker/src/runner/kubernetes.rs
+++ b/components/builder-worker/src/runner/kubernetes.rs
@@ -32,7 +32,13 @@ lazy_static! {
     );
 }
 
+pub struct KubernetesExporterSpec {
+    pub kubeconfig: String,
+    pub replicas: i32,
+}
+
 pub struct KubernetesExporter<'a> {
+    spec: KubernetesExporterSpec,
     workspace: &'a Workspace,
     bldr_url: &'a str,
 }
@@ -41,6 +47,10 @@ impl<'a> KubernetesExporter<'a> {
     /// Creates a new Kubernetes exporter for a given `Workspace` and Builder URL.
     pub fn new(workspace: &'a Workspace, bldr_url: &'a str) -> Self {
         KubernetesExporter {
+            spec: KubernetesExporterSpec {
+                kubeconfig: String::from("/opt/kubeconfig"),
+                replicas: 1,
+            },
             workspace: workspace,
             bldr_url: bldr_url,
         }
@@ -96,6 +106,8 @@ impl<'a> KubernetesExporter<'a> {
     fn apply_to_cluster(&self, exporter: Child, log_pipe: &mut LogPipe) -> Result<ExitStatus> {
 
         let mut cmd = Command::new("/usr/local/bin/kubectl");
+        cmd.arg("--kubeconfig");
+        cmd.arg(&self.spec.kubeconfig);
         cmd.arg("apply");
         cmd.arg("-f");
         cmd.arg("-");

--- a/components/builder-worker/src/runner/kubernetes.rs
+++ b/components/builder-worker/src/runner/kubernetes.rs
@@ -31,6 +31,12 @@ lazy_static! {
         "hab-pkg-export-kubernetes",
         include_str!(concat!(env!("OUT_DIR"), "/KUBERNETES_EXPORTER_PKG_IDENT")),
     );
+
+    /// Absolute path to the kubectl program
+    static ref KUBECTL_PROGRAM: PathBuf = hfs::resolve_cmd_in_pkg(
+        "kubectl",
+        include_str!(concat!(env!("OUT_DIR"), "/KUBECTL_PKG_IDENT")),
+    );
 }
 
 const KUBECONFIG_ENVVAR: &'static str = "KUBECONFIG";
@@ -105,7 +111,7 @@ impl<'a> KubernetesExporter<'a> {
 
     fn apply_to_cluster(&self, exporter: Child, log_pipe: &mut LogPipe) -> Result<ExitStatus> {
 
-        let mut cmd = Command::new("/usr/local/bin/kubectl");
+        let mut cmd = Command::new(&*KUBECTL_PROGRAM);
         cmd.arg("apply");
         cmd.arg("-f");
         cmd.arg("-");

--- a/components/builder-worker/src/runner/kubernetes.rs
+++ b/components/builder-worker/src/runner/kubernetes.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus, Stdio};
+
+use hab_core::env;
+use hab_core::fs as hfs;
+
+use error::{Error, Result};
+use runner::log_pipe::LogPipe;
+use runner::{NONINTERACTIVE_ENVVAR, RUNNER_DEBUG_ENVVAR};
+use runner::workspace::Workspace;
+
+lazy_static! {
+    /// Absolute path to the Docker exporter program
+    static ref KUBERNETES_EXPORTER_PROGRAM: PathBuf = hfs::resolve_cmd_in_pkg(
+        "hab-pkg-export-kubernetes",
+        include_str!(concat!(env!("OUT_DIR"), "/KUBERNETES_EXPORTER_PKG_IDENT")),
+    );
+}
+
+pub struct KubernetesExporter<'a> {
+    workspace: &'a Workspace,
+    bldr_url: &'a str,
+}
+
+impl<'a> KubernetesExporter<'a> {
+    /// Creates a new Kubernetes exporter for a given `Workspace` and Builder URL.
+    pub fn new(workspace: &'a Workspace, bldr_url: &'a str) -> Self {
+        KubernetesExporter {
+            workspace: workspace,
+            bldr_url: bldr_url,
+        }
+    }
+
+    /// Spawns a Kubernetes export command, pipes output streams to the given `LogPipe`
+    /// and returns the process' `ExitStatus`.
+    ///
+    /// # Errors
+    ///
+    /// * If the child process can't be spawned
+    /// * If the calling thread can't wait on the child process
+    /// * If the `LogPipe` fails to pipe output
+    pub fn export(&self, log_pipe: &mut LogPipe) -> Result<ExitStatus> {
+        let exporter = self.spawn_exporter().map_err(Error::Exporter)?;
+
+        let exit_status = self.apply_to_cluster(exporter, log_pipe)?;
+        debug!(
+            "completed kubernetes export command, status={:?}",
+            exit_status
+        );
+        Ok(exit_status)
+    }
+
+    fn spawn_exporter(&self) -> io::Result<Child> {
+
+        let mut cmd = Command::new(&*KUBERNETES_EXPORTER_PROGRAM);
+        cmd.current_dir(self.workspace.root());
+
+        cmd.arg("--count");
+        cmd.arg(format!("{}", self.spec.replicas));
+        cmd.arg("--output");
+        cmd.arg("-");
+        cmd.arg(self.workspace.job.get_project().get_name()); // Locally built artifact
+
+        debug!(
+            "building kubernetes export command, cmd={}",
+            format!("building kubernetes export command, cmd={:?}", &cmd)
+        );
+        cmd.env_clear();
+        if let Some(_) = env::var_os(RUNNER_DEBUG_ENVVAR) {
+            cmd.env("RUST_LOG", "debug");
+        }
+        cmd.env(NONINTERACTIVE_ENVVAR, "true"); // Disables progress bars
+        cmd.env("TERM", "xterm-256color"); // Emits ANSI color codes
+
+        cmd.stdout(Stdio::piped());
+
+        debug!("spawning kubernetes export command");
+        cmd.spawn()
+    }
+
+    fn apply_to_cluster(&self, exporter: Child, log_pipe: &mut LogPipe) -> Result<ExitStatus> {
+
+        let mut cmd = Command::new("/usr/local/bin/kubectl");
+        cmd.arg("apply");
+        cmd.arg("-f");
+        cmd.arg("-");
+
+        debug!("building kubectl command, cmd={:?}", &cmd);
+        cmd.env_clear();
+        if let Some(_) = env::var_os(RUNNER_DEBUG_ENVVAR) {
+            cmd.env("RUST_LOG", "debug");
+        }
+        cmd.env(NONINTERACTIVE_ENVVAR, "true"); // Disables progress bars
+        cmd.env("TERM", "xterm-256color"); // Emits ANSI color codes
+
+        cmd.stdin(exporter.stdout.unwrap());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        debug!("spawning kubectl command");
+        let mut child = cmd.spawn().map_err(Error::Exporter)?;
+        log_pipe.pipe(&mut child)?;
+        let exit_status = child.wait().map_err(Error::Exporter)?;
+        debug!("deploying to cluster, status={:?}", exit_status);
+        Ok(exit_status)
+    }
+}

--- a/components/builder-worker/src/runner/log_pipe.rs
+++ b/components/builder-worker/src/runner/log_pipe.rs
@@ -70,6 +70,14 @@ impl LogPipe {
             self.stream_lines(reader)?;
         }
         self.logger.log("Finished logging stdout");
+
+        self.logger.log("About to log stderr");
+        if let Some(ref mut stderr) = process.stderr {
+            let reader = BufReader::new(stderr);
+            self.stream_lines(reader)?;
+        }
+        self.logger.log("Finished logging stderr");
+
         Ok(())
     }
 

--- a/components/builder-worker/src/runner/log_pipe.rs
+++ b/components/builder-worker/src/runner/log_pipe.rs
@@ -70,14 +70,6 @@ impl LogPipe {
             self.stream_lines(reader)?;
         }
         self.logger.log("Finished logging stdout");
-
-        self.logger.log("About to log stderr");
-        if let Some(ref mut stderr) = process.stderr {
-            let reader = BufReader::new(stderr);
-            self.stream_lines(reader)?;
-        }
-        self.logger.log("Finished logging stderr");
-
         Ok(())
     }
 

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod studio;
 mod docker;
+mod kubernetes;
 mod log_pipe;
 mod postprocessor;
 mod publisher;
@@ -46,6 +47,7 @@ use self::log_pipe::LogPipe;
 use self::postprocessor::post_process;
 use self::studio::{key_path, Studio, STUDIO_GROUP, STUDIO_USER};
 use self::docker::DockerExporter;
+use self::kubernetes::KubernetesExporter;
 use self::workspace::Workspace;
 use config::Config;
 use error::{Error, Result};
@@ -401,6 +403,22 @@ impl Runner {
             }
         }
 
+        if self.has_kubernetes_integration() {
+            if self.workspace.last_built()?.is_a_service() {
+                debug!("Found runnable package, running kubernetes export");
+                log_pipe.pipe_stdout(
+                    b"\n--- BEGIN: Kubernetes export ---\n",
+                )?;
+                status = KubernetesExporter::new(
+                    &self.workspace,
+                    &self.config.bldr_url,
+                ).export(&mut log_pipe)?;
+                log_pipe.pipe_stdout(b"\n--- END: Kubernetes export ---\n")?;
+            } else {
+                debug!("Package not runnable, skipping kubernetes export");
+            }
+        }
+
         if status.success() {
             self.workspace.last_built()
         } else {
@@ -503,6 +521,11 @@ impl Runner {
     /// has been validated.
     fn has_docker_integration(&self) -> bool {
         !self.workspace.job.get_project_integrations().is_empty()
+    }
+
+    fn has_kubernetes_integration(&self) -> bool {
+        // demo
+        true
     }
 }
 

--- a/components/builder-worker/src/runner/mod.rs
+++ b/components/builder-worker/src/runner/mod.rs
@@ -410,6 +410,7 @@ impl Runner {
                     b"\n--- BEGIN: Kubernetes export ---\n",
                 )?;
                 status = KubernetesExporter::new(
+                    util::kubernetes_exporter_spec(&self.workspace),
                     &self.workspace,
                     &self.config.bldr_url,
                 ).export(&mut log_pipe)?;
@@ -520,11 +521,12 @@ impl Runner {
     /// and we are assuming that any calls to this method will happen after the integration data
     /// has been validated.
     fn has_docker_integration(&self) -> bool {
+        // TODO: needs to be changed to fit kubernetes exporter
         !self.workspace.job.get_project_integrations().is_empty()
     }
 
     fn has_kubernetes_integration(&self) -> bool {
-        // demo
+        // TODO: how should this be done as ^ won't work anymore
         true
     }
 }

--- a/components/builder-worker/src/runner/util.rs
+++ b/components/builder-worker/src/runner/util.rs
@@ -48,15 +48,29 @@ pub fn chown_recursive<P: AsRef<Path>>(path: P, uid: u32, gid: u32) -> Result<()
 
 /// Validate integration data in job.
 pub fn validate_integrations(workspace: &Workspace) -> Result<()> {
+
+    validate_docker_integrations(workspace)?;
+    validate_kubernetes_integrations(workspace)?;
+
+    debug!("validated integrations");
+    Ok(())
+}
+
+fn validate_docker_integrations(workspace: &Workspace) -> Result<()> {
     // Validate project integration
     {
-        let prj_integrations = workspace.job.get_project_integrations();
-        if prj_integrations.is_empty() {
-            // No project integrations, that's cool, we're done!
-            return Ok(());
-        }
-
-        let prj_integration = prj_integrations.first().unwrap();
+        let prj_integration = match workspace
+            .job
+            .get_project_integrations()
+            .iter()
+            .filter(|e| e.get_integration() == "docker")
+            .nth(0) {
+            Some(i) => i,
+            None => {
+                // No project integrations, that's cool, we're done!
+                return Ok(());
+            }
+        };
 
         // TODO fn: use a struct and serde to do heavy lifting
         let opts: JsonValue = match serde_json::from_str(prj_integration.get_body()) {
@@ -122,13 +136,19 @@ pub fn validate_integrations(workspace: &Workspace) -> Result<()> {
     }
     // Validate origin integration
     {
-        let org_integrations = workspace.job.get_integrations();
-        if org_integrations.is_empty() {
-            return Err(Error::InvalidIntegrations(format!(
-                "missing Docker credentials from origin integrations"
-            )));
-        }
-        let org_integration = org_integrations.first().unwrap();
+        let org_integration = match workspace
+            .job
+            .get_integrations()
+            .iter()
+            .filter(|e| e.get_integration() == "docker")
+            .nth(0) {
+            Some(i) => i,
+            None => {
+                return Err(Error::InvalidIntegrations(format!(
+                    "missing Docker credentials from origin integrations"
+                )));
+            }
+        };
 
         // TODO fn: use a struct and serde to do heavy lifting
         let creds: JsonValue = match serde_json::from_str(org_integration.get_body()) {
@@ -166,10 +186,112 @@ pub fn validate_integrations(workspace: &Workspace) -> Result<()> {
             }
         }
     }
-    debug!("validated integrations");
+    debug!("validated docker integrations");
     Ok(())
 }
 
+fn validate_kubernetes_integrations(workspace: &Workspace) -> Result<()> {
+    // Validate project integration
+    {
+        let prj_integration = match workspace
+            .job
+            .get_project_integrations()
+            .iter()
+            .filter(|e| e.get_integration() == "kubernetes")
+            .nth(0) {
+            Some(i) => i,
+            None => {
+
+                // No project integrations, that's cool, we're done!
+                return Ok(());
+            }
+        };
+
+        // TODO fn: use a struct and serde to do heavy lifting
+        let opts: JsonValue = match serde_json::from_str(prj_integration.get_body()) {
+            Ok(json) => json,
+            Err(err) => {
+                return Err(Error::InvalidIntegrations(format!(
+                    "project integration body does not deserialize as JSON: {:?}",
+                    err
+                )))
+            }
+        };
+        // Required keys with string values
+        for int_key in vec!["replicas"].iter() {
+            match opts.get(int_key) {
+                Some(val) => {
+                    if !val.is_i64() {
+                        return Err(Error::InvalidIntegrations(format!(
+                            "project integration {} value must be an i64",
+                            int_key
+                        )));
+                    }
+                }
+                None => {
+                    return Err(Error::InvalidIntegrations(
+                        format!("origin integration {} missing", int_key),
+                    ));
+                }
+            }
+        }
+    }
+    // Validate origin integration
+    {
+        let org_integration = match workspace
+            .job
+            .get_integrations()
+            .iter()
+            .filter(|e| e.get_integration() == "kubernetes")
+            .nth(0) {
+            Some(i) => i,
+            None => {
+                return Err(Error::InvalidIntegrations(format!(
+                    "missing Kubernetes kubeconfig from origin integrations"
+                )));
+            }
+        };
+
+        // TODO fn: use a struct and serde to do heavy lifting
+        let creds: JsonValue = match serde_json::from_str(org_integration.get_body()) {
+            Ok(json) => json,
+            Err(err) => {
+                return Err(Error::InvalidIntegrations(format!(
+                    "origin integration body does not deserialize as JSON: {:?}",
+                    err
+                )))
+            }
+        };
+        // Required keys with string values
+        for str_key in vec!["kubeconfig_path"].iter() {
+            match creds.get(str_key) {
+                Some(s) => {
+                    if s.is_string() {
+                        if s.as_str().unwrap().is_empty() {
+                            return Err(Error::InvalidIntegrations(format!(
+                                "origin integration {} value must be a nonempty string",
+                                str_key
+                            )));
+                        }
+                    } else {
+                        return Err(Error::InvalidIntegrations(format!(
+                            "origin integration {} value must be a string",
+                            str_key
+                        )));
+                    }
+                }
+                None => {
+                    return Err(Error::InvalidIntegrations(
+                        format!("origin integration {} missing", str_key),
+                    ));
+                }
+            }
+        }
+    }
+
+    debug!("validated kubernetes integrations");
+    Ok(())
+}
 
 /// Builds the Docker exporter details from the origin and project integrations.
 pub fn docker_exporter_spec(workspace: &Workspace) -> DockerExporterSpec {
@@ -181,9 +303,13 @@ pub fn docker_exporter_spec(workspace: &Workspace) -> DockerExporterSpec {
     // above. As a result, Any panics that occur are most likely due to programmer error and not
     // input validation.
 
-    let origin_integration = workspace.job.get_integrations().first().expect(
-        "Origin integrations must not be empty",
-    );
+    let origin_integration = workspace
+        .job
+        .get_integrations()
+        .iter()
+        .filter(|e| e.get_integration() == "docker")
+        .nth(0)
+        .expect("Origin integrations must not be empty");
 
     let creds: JsonValue = serde_json::from_str(origin_integration.get_body()).expect(
         "Origin integrations body must be JSON",
@@ -193,7 +319,9 @@ pub fn docker_exporter_spec(workspace: &Workspace) -> DockerExporterSpec {
         workspace
             .job
             .get_project_integrations()
-            .first()
+            .iter()
+            .filter(|e| e.get_integration() == "docker")
+            .nth(0)
             .expect("Project integrations must not be empty")
             .get_body(),
     ).expect("Project integrations body must be JSON");
@@ -240,10 +368,41 @@ pub fn docker_exporter_spec(workspace: &Workspace) -> DockerExporterSpec {
 
 /// Builds the Docker exporter details from the origin and project integrations.
 pub fn kubernetes_exporter_spec(workspace: &Workspace) -> KubernetesExporterSpec {
-    // TODO: hardcoded until rebase
+
+    let creds: JsonValue = serde_json::from_str(
+        workspace
+            .job
+            .get_integrations()
+            .iter()
+            .filter(|e| e.get_integration() == "kubernetes")
+            .nth(0)
+            .expect("Origin integration for kubernetes must not be empty")
+            .get_body(),
+    ).expect("Origin integration body must be JSON");
+
+
+    let opts: JsonValue = serde_json::from_str(
+        workspace
+            .job
+            .get_project_integrations()
+            .iter()
+            .filter(|e| e.get_integration() == "kubernetes")
+            .nth(0)
+            .expect("Kubernetes integration must be set")
+            .get_body(),
+    ).expect("Project integration body must be JSON");
+
     KubernetesExporterSpec {
-        kubeconfig_path: "/opt/kubeconfig",
-        replicas: 1,
+        kubeconfig_path: creds
+            .get("kubeconfig_path")
+            .expect("kubeconfig_path key is present")
+            .as_str()
+            .expect("kubeconfig_path value is a string")
+            .to_string(),
+        replicas: opts.get("replicas")
+            .expect("replicas key is present")
+            .as_i64()
+            .expect("replicas value is an i64"),
     }
 }
 

--- a/components/builder-worker/src/runner/util.rs
+++ b/components/builder-worker/src/runner/util.rs
@@ -63,7 +63,7 @@ fn validate_docker_integrations(workspace: &Workspace) -> Result<()> {
             .job
             .get_project_integrations()
             .iter()
-            .filter(|e| e.get_integration() == "docker")
+            // .filter(|e| e.get_integration() == "docker")
             .nth(0) {
             Some(i) => i,
             None => {
@@ -192,50 +192,50 @@ fn validate_docker_integrations(workspace: &Workspace) -> Result<()> {
 
 fn validate_kubernetes_integrations(workspace: &Workspace) -> Result<()> {
     // Validate project integration
-    {
-        let prj_integration = match workspace
-            .job
-            .get_project_integrations()
-            .iter()
-            .filter(|e| e.get_integration() == "kubernetes")
-            .nth(0) {
-            Some(i) => i,
-            None => {
+    // {
+    //     let prj_integration = match workspace
+    //         .job
+    //         .get_project_integrations()
+    //         .iter()
+    //         .filter(|e| e.get_integration() == "kubernetes")
+    //         .nth(0) {
+    //         Some(i) => i,
+    //         None => {
 
-                // No project integrations, that's cool, we're done!
-                return Ok(());
-            }
-        };
+    //             // No project integrations, that's cool, we're done!
+    //             return Ok(());
+    //         }
+    //     };
 
-        // TODO fn: use a struct and serde to do heavy lifting
-        let opts: JsonValue = match serde_json::from_str(prj_integration.get_body()) {
-            Ok(json) => json,
-            Err(err) => {
-                return Err(Error::InvalidIntegrations(format!(
-                    "project integration body does not deserialize as JSON: {:?}",
-                    err
-                )))
-            }
-        };
-        // Required keys with string values
-        for int_key in vec!["replicas"].iter() {
-            match opts.get(int_key) {
-                Some(val) => {
-                    if !val.is_i64() {
-                        return Err(Error::InvalidIntegrations(format!(
-                            "project integration {} value must be an i64",
-                            int_key
-                        )));
-                    }
-                }
-                None => {
-                    return Err(Error::InvalidIntegrations(
-                        format!("origin integration {} missing", int_key),
-                    ));
-                }
-            }
-        }
-    }
+    //     // TODO fn: use a struct and serde to do heavy lifting
+    //     let opts: JsonValue = match serde_json::from_str(prj_integration.get_body()) {
+    //         Ok(json) => json,
+    //         Err(err) => {
+    //             return Err(Error::InvalidIntegrations(format!(
+    //                 "project integration body does not deserialize as JSON: {:?}",
+    //                 err
+    //             )))
+    //         }
+    //     };
+    //     // Required keys with string values
+    //     for int_key in vec!["replicas"].iter() {
+    //         match opts.get(int_key) {
+    //             Some(val) => {
+    //                 if !val.is_i64() {
+    //                     return Err(Error::InvalidIntegrations(format!(
+    //                         "project integration {} value must be an i64",
+    //                         int_key
+    //                     )));
+    //                 }
+    //             }
+    //             None => {
+    //                 return Err(Error::InvalidIntegrations(
+    //                     format!("origin integration {} missing", int_key),
+    //                 ));
+    //             }
+    //         }
+    //     }
+    // }
     // Validate origin integration
     {
         let org_integration = match workspace
@@ -287,6 +287,25 @@ fn validate_kubernetes_integrations(workspace: &Workspace) -> Result<()> {
                 }
             }
         }
+        // Required keys with string values
+        for int_key in vec!["replicas"].iter() {
+            match creds.get(int_key) {
+                Some(val) => {
+                    if !val.is_i64() {
+                        return Err(Error::InvalidIntegrations(format!(
+                            "project integration {} value must be an i64",
+                            int_key
+                        )));
+                    }
+                }
+                None => {
+                    return Err(Error::InvalidIntegrations(
+                        format!("origin integration {} missing", int_key),
+                    ));
+                }
+            }
+        }
+
     }
 
     debug!("validated kubernetes integrations");
@@ -320,7 +339,7 @@ pub fn docker_exporter_spec(workspace: &Workspace) -> DockerExporterSpec {
             .job
             .get_project_integrations()
             .iter()
-            .filter(|e| e.get_integration() == "docker")
+            // .filter(|e| e.get_integration() == "docker")
             .nth(0)
             .expect("Project integrations must not be empty")
             .get_body(),
@@ -381,16 +400,16 @@ pub fn kubernetes_exporter_spec(workspace: &Workspace) -> KubernetesExporterSpec
     ).expect("Origin integration body must be JSON");
 
 
-    let opts: JsonValue = serde_json::from_str(
-        workspace
-            .job
-            .get_project_integrations()
-            .iter()
-            .filter(|e| e.get_integration() == "kubernetes")
-            .nth(0)
-            .expect("Kubernetes integration must be set")
-            .get_body(),
-    ).expect("Project integration body must be JSON");
+    // let opts: JsonValue = serde_json::from_str(
+    //     workspace
+    //         .job
+    //         .get_project_integrations()
+    //         .iter()
+    //         .filter(|e| e.get_integration() == "kubernetes")
+    //         .nth(0)
+    //         .expect("Kubernetes integration must be set")
+    //         .get_body(),
+    // ).expect("Project integration body must be JSON");
 
     KubernetesExporterSpec {
         kubeconfig_path: creds
@@ -399,7 +418,7 @@ pub fn kubernetes_exporter_spec(workspace: &Workspace) -> KubernetesExporterSpec
             .as_str()
             .expect("kubeconfig_path value is a string")
             .to_string(),
-        replicas: opts.get("replicas")
+        replicas: creds.get("replicas")
             .expect("replicas key is present")
             .as_i64()
             .expect("replicas value is an i64"),

--- a/components/builder-worker/src/runner/util.rs
+++ b/components/builder-worker/src/runner/util.rs
@@ -19,6 +19,7 @@ use serde_json::{self, Value as JsonValue};
 
 use error::{Error, Result};
 use runner::docker::DockerExporterSpec;
+use runner::kubernetes::KubernetesExporterSpec;
 use runner::workspace::Workspace;
 
 // TODO fn: The horror... well, it's not that bad. There isn't a quick win for recursive chown'ing
@@ -234,6 +235,15 @@ pub fn docker_exporter_spec(workspace: &Workspace) -> DockerExporterSpec {
             .as_bool()
             .expect("version_release_tag value is a bool"),
         custom_tag: custom_tag,
+    }
+}
+
+/// Builds the Docker exporter details from the origin and project integrations.
+pub fn kubernetes_exporter_spec(workspace: &Workspace) -> KubernetesExporterSpec {
+    // TODO: hardcoded until rebase
+    KubernetesExporterSpec {
+        kubeconfig_path: "/opt/kubeconfig",
+        replicas: 1,
     }
 }
 


### PR DESCRIPTION
~~This is mostly for a demo. It has hardcoded paths and configs!~~

I cleaned up the implementation, removed the hard-coded values and replaced them with API integrations (like the docker exporter does).
There is no UI for this integration yet but it should be possible via raw API calls.

TODO:
- [x] use kubectl from hab pkg
- [ ] fix the missing parts https://github.com/kinvolk/habitat/pull/8#issuecomment-351742190 
- [ ] a way to set the integration options via UI (not this PR)

---

to test these changes:

0. do `git cherry-pick origin/master..kinvolk/schu/vagrant`
1. setup local builder. Follow the steps [here](https://github.com/kinvolk/habitat/blob/schu/vagrant/BUILDER_VAGRANT.md)
2. we also need `core/kubernetes` in the local core origin:
```bash
$ hab pkg install core/kubernetes
$ package_load /hab/cache/artifacts/core-kubernetes-*.hart
```
3. since there is no ui yet we need to create the integrations from the cli
```bash
$ http POST localhost:9636/v1/depot/origins/<your_origin>/integrations/kubernetes/<integration_name> "Authorization:Bearer:${HAB_ORIGIN_AUTH}" kubeconfig_path=<path_to_kubeconfig>
```
4. upload the kubeconfig to the path set above

---

So far I have not managed to test the full integration myself