### PR TITLE
Add helm exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "habitat_pkg_export_helm"
+version = "0.0.0"
+dependencies = [
+ "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (git+https://github.com/withoutboats/failure.git)",
+ "habitat_common 0.0.0",
+ "habitat_core 0.0.0",
+ "habitat_pkg_export_docker 0.0.0",
+ "habitat_pkg_export_kubernetes 0.0.0",
+ "handlebars 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "habitat_pkg_export_kubernetes"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "components/net",
   "components/op",
   "components/pkg-export-docker",
+  "components/pkg-export-helm",
   "components/pkg-export-kubernetes",
   "components/segment-api-client",
   "components/sup"

--- a/components/hab/src/command/pkg/export/cf.rs
+++ b/components/hab/src/command/pkg/export/cf.rs
@@ -19,80 +19,17 @@ use common::ui::UI;
 use error::Result;
 
 const EXPORT_CMD: &'static str = "hab-pkg-cfize";
+const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_CFIZE_BINARY";
+const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-cfize";
+const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_CFIZE_PKG_IDENT";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-    inner::start(ui, args)
-}
-
-#[cfg(target_os = "linux")]
-mod inner {
-    use std::ffi::OsString;
-    use std::path::PathBuf;
-    use std::str::FromStr;
-
-    use common::ui::UI;
-    use hcore::crypto::{init, default_cache_key_path};
-    use hcore::env as henv;
-    use hcore::fs::find_command;
-    use hcore::os::process;
-    use hcore::package::PackageIdent;
-
-    use error::{Error, Result};
-    use exec;
-    use VERSION;
-    use super::EXPORT_CMD;
-
-    const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_CFIZE_BINARY";
-    const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-cfize";
-    const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_CFIZE_PKG_IDENT";
-
-    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-        let command = match henv::var(EXPORT_CMD_ENVVAR) {
-            Ok(command) => PathBuf::from(command),
-            Err(_) => {
-                init();
-                let ident = match henv::var(EXPORT_PKG_IDENT_ENVVAR) {
-                    Ok(ref ident_str) => PackageIdent::from_str(ident_str)?,
-                    Err(_) => {
-                        let version: Vec<&str> = VERSION.split("/").collect();
-                        PackageIdent::from_str(&format!("{}/{}", EXPORT_PKG_IDENT, version[0]))?
-                    }
-                };
-                let cmd = exec::command_from_min_pkg(
-                    ui,
-                    EXPORT_CMD,
-                    &ident,
-                    &default_cache_key_path(None),
-                    0,
-                )?;
-                PathBuf::from(cmd)
-            }
-        };
-        if let Some(cmd) = find_command(&command) {
-            Ok(process::become_command(cmd, args)?)
-        } else {
-            Err(Error::ExecCommandNotFound(command))
-        }
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-mod inner {
-    use std::ffi::OsString;
-
-    use common::ui::UI;
-
-    use error::{Error, Result};
-    use super::EXPORT_CMD;
-
-    pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
-        let cmd = EXPORT_CMD.replace("hab", "").replace("-", " ");
-        ui.warn(format!(
-            "Running 'hab {}' on this operating system is not yet supported. \
-            Try running this command again on 64-bit Linux.",
-            &cmd
-        ))?;
-        ui.br()?;
-        Err(Error::SubcommandNotSupported(cmd.to_string()))
-    }
+    ::command::pkg::export::export_common::start(
+        ui,
+        args,
+        EXPORT_CMD,
+        EXPORT_CMD_ENVVAR,
+        EXPORT_PKG_IDENT,
+        EXPORT_PKG_IDENT_ENVVAR,
+    )
 }

--- a/components/hab/src/command/pkg/export/docker.rs
+++ b/components/hab/src/command/pkg/export/docker.rs
@@ -19,80 +19,17 @@ use common::ui::UI;
 use error::Result;
 
 const EXPORT_CMD: &'static str = "hab-pkg-export-docker";
+const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_DOCKER_BINARY";
+const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-docker";
+const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_DOCKER_PKG_IDENT";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-    inner::start(ui, args)
-}
-
-#[cfg(not(target_os = "macos"))]
-mod inner {
-    use std::ffi::OsString;
-    use std::path::PathBuf;
-    use std::str::FromStr;
-
-    use common::ui::UI;
-    use hcore::crypto::{init, default_cache_key_path};
-    use hcore::env as henv;
-    use hcore::fs::find_command;
-    use hcore::os::process;
-    use hcore::package::PackageIdent;
-
-    use error::{Error, Result};
-    use exec;
-    use VERSION;
-    use super::EXPORT_CMD;
-
-    const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_DOCKER_BINARY";
-    const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-docker";
-    const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_DOCKER_PKG_IDENT";
-
-    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-        let command = match henv::var(EXPORT_CMD_ENVVAR) {
-            Ok(command) => PathBuf::from(command),
-            Err(_) => {
-                init();
-                let ident = match henv::var(EXPORT_PKG_IDENT_ENVVAR) {
-                    Ok(ref ident_str) => PackageIdent::from_str(ident_str)?,
-                    Err(_) => {
-                        let version: Vec<&str> = VERSION.split("/").collect();
-                        PackageIdent::from_str(&format!("{}/{}", EXPORT_PKG_IDENT, version[0]))?
-                    }
-                };
-                let cmd = exec::command_from_min_pkg(
-                    ui,
-                    EXPORT_CMD,
-                    &ident,
-                    &default_cache_key_path(None),
-                    0,
-                )?;
-                PathBuf::from(cmd)
-            }
-        };
-        if let Some(cmd) = find_command(&command) {
-            Ok(process::become_command(cmd, args)?)
-        } else {
-            Err(Error::ExecCommandNotFound(command))
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-mod inner {
-    use std::ffi::OsString;
-
-    use common::ui::UI;
-
-    use error::{Error, Result};
-    use super::EXPORT_CMD;
-
-    pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
-        let cmd = EXPORT_CMD.replace("hab", "").replace("-", " ");
-        ui.warn(format!(
-            "Running 'hab {}' on this operating system is not yet supported. \
-            Try running this command again on 64-bit Linux.",
-            &cmd
-        ))?;
-        ui.br()?;
-        Err(Error::SubcommandNotSupported(cmd.to_string()))
-    }
+    ::command::pkg::export::export_common::start(
+        ui,
+        args,
+        EXPORT_CMD,
+        EXPORT_CMD_ENVVAR,
+        EXPORT_PKG_IDENT,
+        EXPORT_PKG_IDENT_ENVVAR,
+    )
 }

--- a/components/hab/src/command/pkg/export/export_common.rs
+++ b/components/hab/src/command/pkg/export/export_common.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2016-2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::OsString;
+
+use common::ui::UI;
+
+use error::Result;
+
+pub fn start(
+    ui: &mut UI,
+    args: Vec<OsString>,
+    export_cmd: &str,
+    export_cmd_envvar: &str,
+    export_pkg_ident: &str,
+    export_pkg_ident_envvar: &str,
+) -> Result<()> {
+    inner::start(
+        ui,
+        args,
+        export_cmd,
+        export_cmd_envvar,
+        export_pkg_ident,
+        export_pkg_ident_envvar,
+    )
+}
+
+#[cfg(target_os = "linux")]
+mod inner {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use common::ui::UI;
+    use hcore::crypto::{init, default_cache_key_path};
+    use hcore::env as henv;
+    use hcore::fs::find_command;
+    use hcore::os::process;
+    use hcore::package::PackageIdent;
+
+    use error::{Error, Result};
+    use exec;
+    use VERSION;
+
+    pub fn start(
+        ui: &mut UI,
+        args: Vec<OsString>,
+        export_cmd: &str,
+        export_cmd_envvar: &str,
+        export_pkg_ident: &str,
+        export_pkg_ident_envvar: &str,
+    ) -> Result<()> {
+        let command = match henv::var(export_cmd_envvar) {
+            Ok(command) => PathBuf::from(command),
+            Err(_) => {
+                init();
+                let ident = match henv::var(export_pkg_ident_envvar) {
+                    Ok(ref ident_str) => PackageIdent::from_str(ident_str)?,
+                    Err(_) => {
+                        let version: Vec<&str> = VERSION.split("/").collect();
+                        PackageIdent::from_str(&format!("{}/{}", export_pkg_ident, version[0]))?
+                    }
+                };
+                let cmd = exec::command_from_min_pkg(
+                    ui,
+                    export_cmd,
+                    &ident,
+                    &default_cache_key_path(None),
+                    0,
+                )?;
+                PathBuf::from(cmd)
+            }
+        };
+        if let Some(cmd) = find_command(&command) {
+            Ok(process::become_command(cmd, args)?)
+        } else {
+            Err(Error::ExecCommandNotFound(command))
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod inner {
+    use std::ffi::OsString;
+
+    use common::ui::UI;
+
+    use error::{Error, Result};
+
+    pub fn start(
+        ui: &mut UI,
+        args: Vec<OsString>,
+        export_cmd: &str,
+        export_cmd_envvar: &str,
+        export_pkg_ident: &str,
+        export_pkg_ident_envvar: &str,
+    ) -> Result<()> {
+        let cmd = export_cmd.replace("hab", "").replace("-", " ");
+        ui.warn(format!(
+            "Running 'hab {}' on this operating system is not yet supported. \
+            Try running this command again on 64-bit Linux.",
+            &cmd
+        ))?;
+        ui.br()?;
+        Err(Error::SubcommandNotSupported(cmd.to_string()))
+    }
+}

--- a/components/hab/src/command/pkg/export/helm.rs
+++ b/components/hab/src/command/pkg/export/helm.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::OsString;
+
+use common::ui::UI;
+
+use error::Result;
+
+const EXPORT_CMD: &'static str = "hab-pkg-export-helm";
+const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_HELM_BINARY";
+const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-helm";
+const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_HELM_PKG_IDENT";
+
+pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
+    ::command::pkg::export::export_common::start(
+        ui,
+        args,
+        EXPORT_CMD,
+        EXPORT_CMD_ENVVAR,
+        EXPORT_PKG_IDENT,
+        EXPORT_PKG_IDENT_ENVVAR,
+    )
+}

--- a/components/hab/src/command/pkg/export/kubernetes.rs
+++ b/components/hab/src/command/pkg/export/kubernetes.rs
@@ -19,77 +19,17 @@ use common::ui::UI;
 use error::Result;
 
 const EXPORT_CMD: &'static str = "hab-pkg-export-kubernetes";
+const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_KUBERNETES_BINARY";
+const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-kubernetes";
+const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_KUBERNETES_PKG_IDENT";
 
 pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-    inner::start(ui, args)
-}
-
-#[cfg(target_os = "linux")]
-mod inner {
-    use std::ffi::OsString;
-    use std::path::PathBuf;
-    use std::str::FromStr;
-
-    use common::ui::UI;
-    use hcore::crypto::{init, default_cache_key_path};
-    use hcore::env as henv;
-    use hcore::fs::find_command;
-    use hcore::os::process;
-    use hcore::package::PackageIdent;
-
-    use error::{Error, Result};
-    use exec;
-    use super::EXPORT_CMD;
-
-    const EXPORT_CMD_ENVVAR: &'static str = "HAB_PKG_EXPORT_KUBERNETES_BINARY";
-    const EXPORT_PKG_IDENT: &'static str = "core/hab-pkg-export-kubernetes";
-    const EXPORT_PKG_IDENT_ENVVAR: &'static str = "HAB_PKG_EXPORT_KUBERNETES_PKG_IDENT";
-
-    pub fn start(ui: &mut UI, args: Vec<OsString>) -> Result<()> {
-        let command = match henv::var(EXPORT_CMD_ENVVAR) {
-            Ok(command) => PathBuf::from(command),
-            Err(_) => {
-                init();
-                let ident = match henv::var(EXPORT_PKG_IDENT_ENVVAR) {
-                    Ok(ref ident_str) => PackageIdent::from_str(ident_str)?,
-                    Err(_) => PackageIdent::from_str(&format!("{}/{}", EXPORT_PKG_IDENT, "0.1.0"))?,
-                };
-                let cmd = exec::command_from_min_pkg(
-                    ui,
-                    EXPORT_CMD,
-                    &ident,
-                    &default_cache_key_path(None),
-                    0,
-                )?;
-                PathBuf::from(cmd)
-            }
-        };
-        if let Some(cmd) = find_command(&command) {
-            Ok(process::become_command(cmd, args)?)
-        } else {
-            Err(Error::ExecCommandNotFound(command))
-        }
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-mod inner {
-    use std::env;
-    use std::ffi::OsString;
-
-    use common::ui::UI;
-
-    use error::{Error, Result};
-    use super::EXPORT_CMD;
-
-    pub fn start(ui: &mut UI, _args: Vec<OsString>) -> Result<()> {
-        let cmd = EXPORT_CMD.replace("hab", "").replace("-", " ");
-        ui.warn(format!(
-            "Running 'hab {}' on this operating system is not yet supported. \
-            Try running this command again on 64-bit Linux.",
-            &cmd
-        ))?;
-        ui.br()?;
-        Err(Error::SubcommandNotSupported(cmd.to_string()))
-    }
+    ::command::pkg::export::export_common::start(
+        ui,
+        args,
+        EXPORT_CMD,
+        EXPORT_CMD_ENVVAR,
+        EXPORT_PKG_IDENT,
+        EXPORT_PKG_IDENT_ENVVAR,
+    )
 }

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -21,6 +21,8 @@ pub mod docker;
 pub mod cf;
 pub mod kubernetes;
 
+mod export_common;
+
 #[allow(dead_code)]
 pub struct ExportFormat {
     pkg_ident: PackageIdent,

--- a/components/hab/src/command/pkg/export/mod.rs
+++ b/components/hab/src/command/pkg/export/mod.rs
@@ -19,6 +19,7 @@ use error::Result;
 
 pub mod docker;
 pub mod cf;
+pub mod helm;
 pub mod kubernetes;
 
 mod export_common;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -704,6 +704,9 @@ fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
         ("pkg", "export", "cf") => {
             command::pkg::export::cf::start(ui, env::args_os().skip(4).collect())
         }
+        ("pkg", "export", "helm") => {
+            command::pkg::export::helm::start(ui, env::args_os().skip(4).collect())
+        }
         ("pkg", "export", "k8s") |
         ("pkg", "export", "kubernetes") => {
             command::pkg::export::kubernetes::start(ui, env::args_os().skip(4).collect())

--- a/components/pkg-export-helm/Cargo.toml
+++ b/components/pkg-export-helm/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "habitat_pkg_export_helm"
+version = "0.0.0"
+authors = ["Zeeshan Ali <zeeshan@kinvolk.io>"]
+build = "../build-habitat.rs"
+workspace = "../../"
+
+[[bin]]
+name = "hab-pkg-export-helm"
+path = "src/main.rs"
+doc = false
+
+[dependencies]
+clap = { version = "*", features = ["suggestions", "color", "unstable"] }
+env_logger = "*"
+habitat_core = { path = "../core" }
+habitat_common = { path = "../common" }
+habitat_pkg_export_docker = { path = "../pkg-export-docker" }
+habitat_pkg_export_kubernetes = { path = "../pkg-export-kubernetes" }
+handlebars = { version = "*", default-features = false }
+log = "*"
+serde = "1.0.2"
+serde_json = "1.0.0"
+failure = { git = "https://github.com/withoutboats/failure.git" }
+
+[features]
+default = []
+functional = []

--- a/components/pkg-export-helm/defaults/HelmChartFile.hbs
+++ b/components/pkg-export-helm/defaults/HelmChartFile.hbs
@@ -1,0 +1,5 @@
+name: {{name}}
+version: {{version}}
+{{#if description}}
+description: {{description}}
+{{/if}}

--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap;
+use std::fs;
+use std::io::Write;
+
+use common::ui::{UI, Status};
+use export_docker;
+use export_docker::Result;
+use export_k8s::{Manifest, ManifestJson};
+
+use chartfile::ChartFile;
+use values::Values;
+
+pub struct Chart<'a> {
+    name: String,
+    habitat_name: String,
+    chartfile: ChartFile,
+    manifest_template: ManifestJson,
+    values: Values,
+    ui: &'a mut UI,
+}
+
+impl<'a> Chart<'a> {
+    pub fn new_for_cli_matches(ui: &'a mut UI, matches: &clap::ArgMatches) -> Result<Self> {
+        if !matches.is_present("NO_DOCKER_IMAGE") {
+            export_docker::export_for_cli_matches(ui, &matches)?;
+        }
+        let manifest = Manifest::new_from_cli_matches(ui, &matches)?;
+        let name = matches
+            .value_of("CHART")
+            .unwrap_or(&manifest.habitat_name)
+            .to_string();
+        let version = matches.value_of("VERSION");
+        let description = matches.value_of("DESCRIPTION");
+        let chartfile = ChartFile::new(&name, version, description)?;
+
+        Ok(Self::new_for_manifest(manifest, name, chartfile, ui))
+    }
+
+    fn new_for_manifest(
+        manifest: Manifest,
+        name: String,
+        chartfile: ChartFile,
+        ui: &'a mut UI,
+    ) -> Self {
+        let main = json!({
+            "metadata_name": "{{.Values.metadataName}}",
+            "habitat_name": "{{.Values.habitatName}}",
+            "image": "{{.Values.imageName}}",
+            "count": "{{.Values.instanceCount}}",
+            "service_topology": "{{.Values.serviceTopology}}",
+            "service_group": manifest.service_group.clone().map(|_| "{{.Values.serviceGroup}}"),
+            "config_secret_name": manifest.config_secret_name
+                .clone()
+                .map(|_| "{{.Values.configSecretName}}"),
+            "ring_secret_name": manifest.ring_secret_name
+                .clone()
+                .map(|_| "{{.Values.ringSecretName}}"),
+            "bind": !manifest.binds.is_empty(),
+        });
+
+        let mut values = Values::new();
+        values.add_entry("metadataName", &manifest.metadata_name);
+        values.add_entry("habitatName", &manifest.habitat_name);
+        values.add_entry("imageName", &manifest.image);
+        values.add_entry("instanceCount", &manifest.count.to_string());
+        values.add_entry("serviceTopology", &manifest.service_topology.to_string());
+        if let Some(ref group) = manifest.service_group {
+            values.add_entry("serviceGroup", group);
+        }
+        if let Some(ref name) = manifest.config_secret_name {
+            values.add_entry("configSecretName", name);
+        }
+        if let Some(ref name) = manifest.ring_secret_name {
+            values.add_entry("ringSecretName", name);
+        }
+
+        let mut binds = Vec::new();
+        let mut i = 0;
+        for bind in &manifest.binds {
+            let name_var = format!("bindName{}", i);
+            let service_var = format!("bindService{}", i);
+            let group_var = format!("bindGroup{}", i);
+            i = i + 1;
+
+            values.add_entry(&name_var, &bind.name);
+            values.add_entry(&service_var, &bind.service);
+            values.add_entry(&group_var, &bind.group);
+
+            let json = json!({
+                "name": format!("{{{{.Values.{}}}}}", name_var),
+                "service": format!("{{{{.Values.{}}}}}", service_var),
+                "group": format!("{{{{.Values.{}}}}}", group_var),
+            });
+
+            binds.push(json);
+        }
+
+        let manifest_template = ManifestJson {
+            main: main,
+            binds: binds,
+        };
+        let habitat_name = manifest.habitat_name;
+
+        Chart {
+            name,
+            habitat_name,
+            chartfile,
+            manifest_template,
+            values,
+            ui,
+        }
+    }
+
+    pub fn generate(&mut self) -> Result<()> {
+        self.ui.status(
+            Status::Creating,
+            format!("chart directory `{}`", self.name),
+        )?;
+        fs::create_dir_all(&self.name)?;
+
+        self.generate_chartfile()?;
+
+        let template_path = format!("{}/{}", self.name, "templates");
+        self.ui.status(
+            Status::Creating,
+            format!("templates directory `{}`", template_path),
+        )?;
+        fs::create_dir_all(&template_path)?;
+        self.generate_manifest_template(&template_path)?;
+
+        self.generate_values()
+    }
+
+    pub fn generate_chartfile(&mut self) -> Result<()> {
+        let path = format!("{}/Chart.yaml", self.name);
+        self.ui.status(
+            Status::Creating,
+            format!("chart file `{}`", path),
+        )?;
+        let mut write = fs::File::create(path)?;
+        let out = self.chartfile.into_string()?;
+
+        write.write(out.as_bytes())?;
+
+        Ok(())
+    }
+
+    pub fn generate_manifest_template(&mut self, template_path: &str) -> Result<()> {
+        let manifest_path = format!("{}/{}.yaml", template_path, self.habitat_name);
+        self.ui.status(
+            Status::Creating,
+            format!("manifest template `{}`", manifest_path),
+        )?;
+        let mut write = fs::File::create(manifest_path)?;
+        let out = self.manifest_template.into_string()?;
+
+        write.write(out.as_bytes())?;
+
+        Ok(())
+    }
+
+    pub fn generate_values(&mut self) -> Result<()> {
+        let path = format!("{}/values.yaml", self.name);
+        self.ui.status(
+            Status::Creating,
+            format!("values file `{}`", path),
+        )?;
+        let mut write = fs::File::create(path)?;
+
+        self.values.generate(&mut write)?;
+
+        Ok(())
+    }
+}

--- a/components/pkg-export-helm/src/chartfile.rs
+++ b/components/pkg-export-helm/src/chartfile.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use failure::SyncFailure;
+use handlebars::Handlebars;
+use serde_json::Value;
+
+use export_docker::Result;
+
+// Keep the default version in main::cli() in sync with this one
+pub const DEFAULT_VERSION: &'static str = "0.0.1";
+
+// Helm chart file template
+const CHARTFILE: &'static str = include_str!("../defaults/HelmChartFile.hbs");
+
+pub struct ChartFile {
+    json: Value,
+}
+
+impl ChartFile {
+    pub fn new(name: &str, version: Option<&str>, description: Option<&str>) -> Result<Self> {
+        let json = json!({
+            "name": name,
+            "version": version.unwrap_or(DEFAULT_VERSION),
+            "description": description,
+        });
+
+        Ok(ChartFile { json })
+    }
+
+    // TODO: Implement TryInto trait instead when it's in stable std crate
+    pub fn into_string(&self) -> Result<String> {
+        let r = Handlebars::new()
+            .template_render(CHARTFILE, &self.json)
+            .map_err(SyncFailure::new)?;
+        let s = r.lines().filter(|l| *l != "").collect::<Vec<_>>().join(
+            "\n",
+        ) + "\n";
+
+        Ok(s)
+    }
+}

--- a/components/pkg-export-helm/src/main.rs
+++ b/components/pkg-export-helm/src/main.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate clap;
+extern crate env_logger;
+extern crate habitat_core as hcore;
+extern crate habitat_common as common;
+extern crate habitat_pkg_export_docker as export_docker;
+extern crate habitat_pkg_export_kubernetes as export_k8s;
+extern crate handlebars;
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate serde_json;
+
+extern crate failure;
+
+mod chart;
+mod chartfile;
+mod values;
+
+use std::result;
+
+use clap::Arg;
+
+use common::ui::UI;
+use export_docker::Result;
+use export_k8s::Cli;
+use hcore::PROGRAM_NAME;
+
+use chart::Chart;
+
+fn main() {
+    env_logger::init().unwrap();
+    let mut ui = UI::default_with_env();
+    let m = cli().get_matches();
+    debug!("clap cli args: {:?}", m);
+
+    if let Err(e) = export_for_cli_matches(&mut ui, &m) {
+        let _ = ui.fatal(e);
+        std::process::exit(1)
+    }
+}
+
+fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches) -> Result<()> {
+    let mut chart = Chart::new_for_cli_matches(ui, matches)?;
+    chart.generate()?;
+
+    Ok(())
+}
+
+fn cli<'a, 'b>() -> clap::App<'a, 'b> {
+    let name: &str = &*PROGRAM_NAME;
+    let about = "Creates a Docker image and generates a Helm chart for the specified Habitat \
+                 package. Habitat operator must be deployed within the Kubernetes cluster before \
+                 the generated chart can be installed.";
+
+    Cli::new(name, about)
+        .add_docker_args()
+        .add_runtime_args()
+        .add_secret_names_args()
+        .add_bind_args()
+        .app
+        .arg(
+            Arg::with_name("CHART")
+                .value_name("CHART")
+                .long("chart")
+                .short("h")
+                .help(
+                    "Name of the chart to create, if different from the package name",
+                ),
+        )
+        .arg(
+            Arg::with_name("VERSION")
+                .value_name("VERSION")
+                .long("version")
+                .validator(valid_version)
+                // Keep the default version here in sync with chartfile::DEFAULT_VERSION
+                .help("Version of the chart to create (default: 0.0.1)"),
+        )
+        .arg(
+            Arg::with_name("DESCRIPTION")
+                .value_name("DESCRIPTION")
+                .long("desc")
+                .help("A single-sentence description"),
+        )
+}
+
+fn valid_version(val: String) -> result::Result<(), String> {
+    let split: Vec<&str> = val.split(".").collect();
+    if split.len() != 3 {
+        return Err(format!("Version '{}' is not valid", &val));
+    }
+
+    for s in split {
+        for c in s.chars() {
+            if !c.is_digit(10) {
+                return Err(format!("Version '{}' is not valid", &val));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_version() {
+        valid_version("0.0.1".to_owned()).unwrap();
+        valid_version("0.1.1".to_owned()).unwrap();
+        valid_version("1.1.1".to_owned()).unwrap();
+        valid_version("1.1.10".to_owned()).unwrap();
+        valid_version("1.10.1".to_owned()).unwrap();
+        valid_version("10.1.1".to_owned()).unwrap();
+
+        assert!(valid_version("1".to_owned()).is_err());
+        assert!(valid_version("1.1".to_owned()).is_err());
+        assert!(valid_version("X".to_owned()).is_err());
+        assert!(valid_version("1.2.Z".to_owned()).is_err());
+        assert!(valid_version("1.1.1.1".to_owned()).is_err());
+        assert!(valid_version("٣.7.৬".to_owned()).is_err());
+    }
+}

--- a/components/pkg-export-helm/src/values.rs
+++ b/components/pkg-export-helm/src/values.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate habitat_pkg_export_docker as export_docker;
+
+use std::io::Write;
+
+use export_docker::Result;
+
+pub struct Values {
+    values: Vec<ValuesEntry>,
+}
+
+impl Values {
+    pub fn new() -> Self {
+        Values { values: Vec::new() }
+    }
+
+    pub fn add_entry(&mut self, variable: &str, value: &str) {
+        self.values.push(ValuesEntry {
+            variable: variable.to_owned(),
+            value: value.to_owned(),
+        });
+    }
+
+    pub fn generate(&self, write: &mut Write) -> Result<()> {
+        let mut out = "".to_owned();
+        for entry in &self.values {
+            out = out + &format!("{}: \"{}\"\n", entry.variable, entry.value);
+        }
+
+        write.write(out.as_bytes())?;
+
+        Ok(())
+    }
+}
+
+struct ValuesEntry {
+    variable: String,
+    value: String,
+}

--- a/components/pkg-export-kubernetes/src/bind.rs
+++ b/components/pkg-export-kubernetes/src/bind.rs
@@ -29,7 +29,7 @@ impl FromStr for Bind {
 
     fn from_str(bind_spec: &str) -> Result<Self, Error> {
         let split: Vec<&str> = bind_spec.split(":").collect();
-        if split.len() < 3 {
+        if split.len() != 3 {
             return Err(Error::InvalidBindSpec(bind_spec.to_owned()));
         }
 

--- a/components/pkg-export-kubernetes/src/bind.rs
+++ b/components/pkg-export-kubernetes/src/bind.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgMatches;
+use std::str::FromStr;
+
+use error::Error;
+
+#[derive(Debug, Clone)]
+pub struct Bind {
+    pub name: String,
+    pub service: String,
+    pub group: String,
+}
+
+impl FromStr for Bind {
+    type Err = Error;
+
+    fn from_str(bind_spec: &str) -> Result<Self, Error> {
+        let split: Vec<&str> = bind_spec.split(":").collect();
+        if split.len() < 3 {
+            return Err(Error::InvalidBindSpec(bind_spec.to_owned()));
+        }
+
+        Ok(Bind {
+            name: split[0].to_owned(),
+            service: split[1].to_owned(),
+            group: split[2].to_owned(),
+        })
+    }
+}
+
+pub fn parse_bind_args(matches: &ArgMatches) -> Result<Vec<Bind>, Error> {
+    let mut binds = Vec::new();
+
+    if let Some(bind_args) = matches.values_of("BIND") {
+        for arg in bind_args {
+            let b = Bind::from_str(arg)?;
+
+            binds.push(b);
+        }
+    };
+
+    Ok(binds)
+}

--- a/components/pkg-export-kubernetes/src/lib.rs
+++ b/components/pkg-export-kubernetes/src/lib.rs
@@ -34,6 +34,7 @@ use common::ui::UI;
 pub mod topology;
 pub mod error;
 pub mod manifest;
+pub mod manifestjson;
 pub mod cli;
 
 use export_docker::Result;
@@ -41,6 +42,7 @@ use export_docker::Result;
 pub use cli::Cli;
 pub use error::Error;
 pub use manifest::Manifest;
+pub use manifestjson::ManifestJson;
 pub use topology::Topology;
 
 // Synced with the version of the Habitat operator.

--- a/components/pkg-export-kubernetes/src/lib.rs
+++ b/components/pkg-export-kubernetes/src/lib.rs
@@ -35,11 +35,13 @@ pub mod topology;
 pub mod error;
 pub mod manifest;
 pub mod manifestjson;
+pub mod bind;
 pub mod cli;
 
 use export_docker::Result;
 
 pub use cli::Cli;
+pub use bind::Bind;
 pub use error::Error;
 pub use manifest::Manifest;
 pub use manifestjson::ManifestJson;

--- a/components/pkg-export-kubernetes/src/lib.rs
+++ b/components/pkg-export-kubernetes/src/lib.rs
@@ -25,6 +25,10 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 
+use std::fs::File;
+use std::io;
+use std::io::prelude::*;
+
 use common::ui::UI;
 
 pub mod topology;
@@ -47,5 +51,10 @@ pub fn export_for_cli_matches(ui: &mut UI, matches: &clap::ArgMatches) -> Result
         export_docker::export_for_cli_matches(ui, &matches)?;
     }
     let mut manifest = Manifest::new_from_cli_matches(ui, &matches)?;
-    manifest.generate()
+
+    let mut write: Box<Write> = match matches.value_of("OUTPUT") {
+        Some(o) if o != "-" => Box::new(File::create(o)?),
+        _ => Box::new(io::stdout()),
+    };
+    manifest.generate(&mut write)
 }

--- a/components/pkg-export-kubernetes/src/manifest.rs
+++ b/components/pkg-export-kubernetes/src/manifest.rs
@@ -35,16 +35,16 @@ const BINDFILE: &'static str = include_str!("../defaults/KubernetesBind.hbs");
 
 #[derive(Debug, Clone)]
 pub struct Manifest {
-    metadata_name: String,
-    habitat_name: String,
-    image: String,
-    count: u64,
-    service_topology: Topology,
-    service_group: Option<String>,
-    config_secret_name: Option<String>,
-    ring_secret_name: Option<String>,
+    pub metadata_name: String,
+    pub habitat_name: String,
+    pub image: String,
+    pub count: u64,
+    pub service_topology: Topology,
+    pub service_group: Option<String>,
+    pub config_secret_name: Option<String>,
+    pub ring_secret_name: Option<String>,
     // TODO: Represent binds with a struct
-    binds: Vec<String>,
+    pub binds: Vec<String>,
 }
 
 impl Manifest {

--- a/components/pkg-export-kubernetes/src/manifest.rs
+++ b/components/pkg-export-kubernetes/src/manifest.rs
@@ -33,6 +33,7 @@ use error::Error;
 const MANIFESTFILE: &'static str = include_str!("../defaults/KubernetesManifest.hbs");
 const BINDFILE: &'static str = include_str!("../defaults/KubernetesBind.hbs");
 
+#[derive(Debug, Clone)]
 pub struct Manifest {
     metadata_name: String,
     habitat_name: String,

--- a/components/pkg-export-kubernetes/src/manifest.rs
+++ b/components/pkg-export-kubernetes/src/manifest.rs
@@ -72,19 +72,15 @@ impl Manifest {
 
         // To allow multiple instances of Habitat application in Kubernetes,
         // random suffix in metadata_name is needed.
-        let metadata_name = format!(
-            "{}-{}{}",
+        let metadata_name =
+            format!(
+            "{}-{}",
             pkg_ident.name,
             rand::thread_rng()
                 .gen_ascii_chars()
                 .filter(|c| c.is_lowercase() || c.is_numeric())
-                .take(4)
+                .take(5)
                 .collect::<String>(),
-            rand::thread_rng()
-                .gen_ascii_chars()
-                .filter(|c| c.is_lowercase() && !c.is_numeric())
-                .take(1)
-                .collect::<String>()
         );
 
         let image = match matches.value_of("IMAGE_NAME") {

--- a/components/pkg-export-kubernetes/src/manifestjson.rs
+++ b/components/pkg-export-kubernetes/src/manifestjson.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2017 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use failure::SyncFailure;
+use handlebars::Handlebars;
+use serde_json::Value;
+
+use export_docker::Result;
+
+use manifest::Manifest;
+use error::Error;
+
+// Kubernetes manifest template
+const MANIFESTFILE: &'static str = include_str!("../defaults/KubernetesManifest.hbs");
+const BINDFILE: &'static str = include_str!("../defaults/KubernetesBind.hbs");
+
+pub struct ManifestJson {
+    pub main: Value,
+    pub binds: Vec<Value>,
+}
+
+impl ManifestJson {
+    pub fn new(manifest: &Manifest) -> Result<Self> {
+        let main = json!({
+            "metadata_name": manifest.metadata_name,
+            "habitat_name": manifest.habitat_name,
+            "image": manifest.image,
+            "count": manifest.count,
+            "service_topology": manifest.service_topology.to_string(),
+            "service_group": manifest.service_group,
+            "config_secret_name": manifest.config_secret_name,
+            "ring_secret_name": manifest.ring_secret_name,
+            "bind": manifest.binds,
+        });
+
+        let mut binds = Vec::new();
+        for bind in &manifest.binds {
+            let split: Vec<&str> = bind.split(":").collect();
+            if split.len() < 3 {
+                return Err(Error::InvalidBindSpec(bind.to_string()).into());
+            }
+
+            let json = json!({
+                "name": split[0],
+                "service": split[1],
+                "group": split[2],
+            });
+
+            binds.push(json);
+        }
+
+        Ok(ManifestJson {
+            main: main,
+            binds: binds,
+        })
+    }
+
+    // TODO: Implement TryInto trait instead when it's in stable std crate
+    pub fn into_string(&self) -> Result<String> {
+        let r = Handlebars::new()
+            .template_render(MANIFESTFILE, &self.main)
+            .map_err(SyncFailure::new)?;
+        let mut s = r.lines().filter(|l| *l != "").collect::<Vec<_>>().join(
+            "\n",
+        ) + "\n";
+
+        for bind in &self.binds {
+            s += &Handlebars::new().template_render(BINDFILE, &bind).map_err(SyncFailure::new)?;
+        }
+
+        Ok(s)
+    }
+}

--- a/components/pkg-export-kubernetes/src/topology.rs
+++ b/components/pkg-export-kubernetes/src/topology.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use error::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Topology {
     Standalone,
     Leader,


### PR DESCRIPTION
Here is the *internal* (I hope) PR for adding the first version of Helm exporter. In my limited testing, it works perfectly, except that the docker image push fails for some reason on me. Could have something to do with fedora being weird about docker again, I don't know. I've a script (to follow, not to run) to test:

```
# Go to dir where the plan.sh lies
cd /home/zeenix/checkout/habitat-example-plans/mynodeapp/

# Build the plan
hab pkg build  -r ${PWD}../studio .

# Export the package
hab pkg export helm --push-image --username zeenix --password pass --registry-url docker.io --registry-type docker results/zeenix-testapp-*.hart

# Run operator
../habitat-operator/habitat-operator --kubeconfig /var/lib/kube-spawn/default/kubeconfig

# Initialize Helm (Tiller)
cat >/tmp/helm.yaml <<EOL
hi
hello
EOL

helm-exec init --service-account helm

# Install/deploy the app already! (but wait for the Helm Tiller pod to get ready)
helm install ./testapp

# Check the app running
kubectl get pods -w
kubectl port-forward PODNAME 8000 &
wget localhost:8000
cat index.html # You should see 'hello world'

# Clean-up after                                                                                                                       
helm delete HELM_APP_NAME # check `helm list` output for finding out the name
docker rmi IMAGE_ID
# Remove docker app from docker hub through web
rm -Rf /home/zeenix/checkout/habitat-example-plans/studio
rm -Rf /home/zeenix/checkout/habitat-example-plans/mynodeapp/results
```

Resolves https://github.com/kinvolk/CLIENT-Chef/issues/36