### PR TITLE
Simplify port handling in butterfly server

### DIFF
--- a/components/butterfly-test/src/lib.rs
+++ b/components/butterfly-test/src/lib.rs
@@ -54,16 +54,13 @@ impl Suitability for NSuitability {
 
 pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> Server {
     SERVER_PORT.compare_and_swap(0, 6666, Ordering::Relaxed);
-    let swim_port = SERVER_PORT.fetch_add(1, Ordering::Relaxed);
-    let gossip_port = SERVER_PORT.fetch_add(1, Ordering::Relaxed);
-    let listen_swim = format!("127.0.0.1:{}", swim_port);
-    let listen_gossip = format!("127.0.0.1:{}", gossip_port);
+    let swim_gossip_port = SERVER_PORT.fetch_add(1, Ordering::Relaxed);
+    let listen_swim_gossip = format!("127.0.0.1:{}", swim_gossip_port);
     let mut member = Member::default();
-    member.set_swim_port(swim_port as i32);
-    member.set_gossip_port(gossip_port as i32);
+    member.set_swim_port(swim_gossip_port as i32);
+    member.set_gossip_port(swim_gossip_port as i32);
     let mut server = Server::new(
-        &listen_swim[..],
-        &listen_gossip[..],
+        &listen_swim_gossip[..],
         member,
         Trace::default(),
         ring_key,
@@ -83,8 +80,8 @@ pub fn member_from_server(server: &Server) -> Member {
     new_member.set_id(String::from(server_member.get_id()));
     new_member.set_incarnation(server_member.get_incarnation());
     new_member.set_address(String::from("127.0.0.1"));
-    new_member.set_swim_port(server.swim_port() as i32);
-    new_member.set_gossip_port(server.gossip_port() as i32);
+    new_member.set_swim_port(server.swim_gossip_port() as i32);
+    new_member.set_gossip_port(server.swim_gossip_port() as i32);
     new_member
 }
 

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -48,17 +48,13 @@ fn main() {
 
     let bind_to_addr = bind_to.parse::<SocketAddr>().unwrap();
     let bind_port = bind_to_addr.port();
-    let mut gossip_bind_addr = bind_to_addr.clone();
-    let gport = bind_port + 1;
-    gossip_bind_addr.set_port(gport);
 
     let mut member = member::Member::default();
     member.set_swim_port(bind_port as i32);
-    member.set_gossip_port(gport as i32);
+    member.set_gossip_port(bind_port as i32);
 
     let mut server = server::Server::new(
         bind_to_addr,
-        gossip_bind_addr,
         member,
         trace::Trace::default(),
         None,

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -52,7 +52,7 @@ impl Pull {
             "Failure to set the ZMQ Pull socket to not use keepalive",
         );
         socket
-            .bind(&format!("tcp://{}", self.server.gossip_addr()))
+            .bind(&format!("tcp://{}", self.server.swim_gossip_addr()))
             .expect("Failure to bind the ZMQ Pull socket to the port");
         'recv: loop {
             if self.server.pause.load(Ordering::Relaxed) {

--- a/components/butterfly/src/trace.rs
+++ b/components/butterfly/src/trace.rs
@@ -308,7 +308,7 @@ macro_rules! trace_it {
                 trace.init($server);
                 let thread = thread::current();
                 let thread_name = thread.name().unwrap_or("undefined");
-                let listening = format!("{}", $server.swim_addr());
+                let listening = format!("{}", $server.swim_gossip_addr());
                 let to_addr = format!("{}", $to_addr);
                 let member_id = $server.member_id();
                 let server_name = $server.name();
@@ -334,7 +334,7 @@ macro_rules! trace_it {
                 trace.init($server);
                 let thread = thread::current();
                 let thread_name = thread.name().unwrap_or("undefined");
-                let listening = format!("{}", $server.swim_addr());
+                let listening = format!("{}", $server.swim_gossip_addr());
                 let to_addr = format!("{}", $to_addr);
                 let member_id = $server.member_id();
                 let server_name = $server.name();
@@ -368,7 +368,7 @@ macro_rules! trace_it {
                 trace.init($server);
                 let thread = thread::current();
                 let thread_name = thread.name().unwrap_or("undefined");
-                let listening = format!("{}", $server.gossip_addr());
+                let listening = format!("{}", $server.swim_gossip_addr());
                 let member_id = $server.member_id();
                 let server_name = $server.name();
                 let rp = match $payload.get_field_type() {

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -36,7 +36,7 @@ fn departure_via_client() {
 
     net.wait_for_gossip_rounds(1);
     let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+        Client::new(net[0].swim_gossip_addr(), None).expect("Cannot create Butterfly Client");
     client
         .send_departure(String::from(net[1].member_id()))
         .expect("Cannot send the departure");

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -36,7 +36,7 @@ fn service_config_via_client() {
 
     net.wait_for_gossip_rounds(1);
     let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+        Client::new(net[0].swim_gossip_addr(), None).expect("Cannot create Butterfly Client");
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_config(

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -41,7 +41,7 @@ fn service_file_via_client() {
 
     net.wait_for_gossip_rounds(1);
     let mut client =
-        Client::new(net[0].gossip_addr(), None).expect("Cannot create Butterfly Client");
+        Client::new(net[0].swim_gossip_addr(), None).expect("Cannot create Butterfly Client");
     let payload = Vec::from("I want to get lost in you, tokyo".as_bytes());
     client
         .send_service_file(

--- a/components/sup/src/manager/mod.rs
+++ b/components/sup/src/manager/mod.rs
@@ -288,7 +288,6 @@ impl Manager {
         let services = Arc::new(RwLock::new(Vec::new()));
         let server = butterfly::Server::new(
             sys.gossip_listen(),
-            sys.gossip_listen(),
             member,
             Trace::default(),
             ring_key,
@@ -532,7 +531,7 @@ impl Manager {
 
         outputln!(
             "Starting gossip-listener on {}",
-            self.butterfly.gossip_addr()
+            self.butterfly.swim_gossip_addr()
         );
         self.butterfly.start(Timing::default())?;
         debug!("gossip-listener started");


### PR DESCRIPTION
The butterfly server allowed to specify a separate port number for
swim connections and a separate port for gossip connections. The only
serious user of the butterfly server, the supervisor, was passing the
same number in for both. It works, because even if butterfly is still
opening two ports, one is a UDP port and the other is TCP port.

Another reason for this change is to simplify the discovery of the
exposed address and port for the supervisor being behind a NAT. This
feature may come in future work revolving around the spanning ring.

Signed-off-by: Krzesimir Nowak <krzesimir@kinvolk.io>


This is conflicting with another PR (#10) I filed today, but that doesn't matter - this is mostly a strawman PR that I want to propose to upstream. Whichever gets merged first - it will become a base of the following PR.