### PR TITLE
Change target line in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .tags*
 .vagrant/
 .vscode
-/target
+target/
 dump.rdb
 log/
 results/


### PR DESCRIPTION
The new pattern ignores all directories named `target`, irrespective of
their location in the repository. This allows it to also ignore e.g.
`components/hab/target`.

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>