### PR TITLE
pkg-export-k8s: Remove redundant newline filtering code

### DIFF
--- a/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
@@ -1,4 +1,4 @@
-{{#if config}}
+{{#if config ~}}
 ---
 ## Secret for initial configuration.
 apiVersion: v1
@@ -9,7 +9,7 @@ type: Opaque
 data:
   ## Each configuration item needs to be encoded in base64.
   user.toml: {{config}}
-{{/if}}
+{{/if ~}}
 ---
 apiVersion: habitat.sh/v1
 kind: Habitat
@@ -26,20 +26,20 @@ spec:
   service:
     ## Habitat topology of the service.
     topology: {{service_topology}}
-{{#if service_group}}
+{{~ #if service_group}}
     ## Habitat service group name, a logical grouping of services
     ## with the same package.
     group: {{service_group}}
-{{/if}}
-{{#if config}}
+{{~ /if ~}}
+{{~ #if config}}
     ## Name of the configuration secret.
     configSecretName: user-toml-secret
-{{/if}}
-{{#if ring_secret_name}}
+{{~ /if ~}}
+{{~ #if ring_secret_name}}
     ## The name of the Kubernetes Secret that contains the ring key, which
     ## encrypts the communication between Habitat supervisors.
     ringSecretName: {{ring_secret_name}}
-{{/if}}
-{{#if bind}}
+{{~ /if ~}}
+{{~ #if bind}}
     bind:
-{{/if}}
+{{~ /if ~}}

--- a/components/pkg-export-kubernetes/src/manifestjson.rs
+++ b/components/pkg-export-kubernetes/src/manifestjson.rs
@@ -77,12 +77,9 @@ impl Into<String> for ManifestJson {
         // come from the crate programmer (e.g they messed-up the manifest template or don't check
         // the user input).
 
-        let r = Handlebars::new()
+        let mut s = Handlebars::new()
             .template_render(MANIFESTFILE, &self.main)
             .expect("Rendering of manifest from template failed");
-        let mut s = r.lines().filter(|l| *l != "").collect::<Vec<_>>().join(
-            "\n",
-        ) + "\n";
 
         for bind in &self.binds {
             s += &Handlebars::new().template_render(BINDFILE, &bind).expect(


### PR DESCRIPTION
Instead use the means provided by Handlebars templating language to
achieve the same in the source template itself.

Signed-off-by: Zeeshan Ali <zeeshan@kinvolk.io>