### PR TITLE
Fix the Helm exporter blogpost

### DIFF
--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -33,7 +33,7 @@ So, for the purposes of this Helm demo to work locally, you now need to do:
 * Start minikube with RBAC enabled: `minikube start --extra-config=apiserver.Authorization.Mode=RBAC` 
 * Tell your machine's Docker daemon to use minikube's instead: `eval $(minikube docker-env)`
 
-If you would prefer to publish your Helm charts to your Dockerhub and have Helm find them there to use on your Kubernetes cluster, that is supported! Please run `hab pkg export helm --help` to see more available options.
+If you would prefer to publish your Helm charts to your Dockerhub and have Helm find them there to use on your Kubernetes cluster, that is supported! Please run `hab pkg export helm --help` to see more available options. (Please note - this command only works on Linux, so if you are not on a Linux machine, you will need to enter the Habitat Studio to run it successfully, using the comman `hab studio enter`). 
 
 ### Go to core-plans/nginx 
 

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -97,7 +97,7 @@ nginx-1.11.10-20180221053714  0s
 
 ==> v1/Pod(related)
 NAME                                             READY  STATUS             RESTARTS  AGE
-honorary-wolf-habitat-operator-7f74859c6d-2jv9b  0/1    ContainerCreating  0         0s
+honorary-wolf-habitat-operator-7f74859c6d-2jv9b  1/1    Running            0         0s
 
 ==> v1/ServiceAccount
 NAME                            SECRETS  AGE

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -34,7 +34,7 @@ So, for the purposes of this Helm demo to work locally, you now need to do:
 * Start minikube with RBAC enabled: `minikube start --extra-config=apiserver.Authorization.Mode=RBAC` 
 * Tell your machine's Docker daemon to use minikube's instead: `eval $(minikube docker-env)`
 
-If you would prefer to publish your Helm charts to your Dockerhub and have Helm find them there to use on your Kubernetes cluster, that is supported! Enter the Habitat Studio (`hab studio enter`) and use `hab pkg export helm --help` to see more available options.
+If you would prefer to publish your Helm charts to your Dockerhub and have Helm find them there to use on your Kubernetes cluster, that is supported! Please run `hab pkg export helm --help` to see more available options.
 
 ### Go to core-plans/nginx 
 

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -26,7 +26,7 @@ And now, let's get started!
 
 **Important Note** 
 
-Minikube uses its own Docker Engine, not your machine's Docker Engine. Habitat Studio uses your machine's Docker Engine. So, in order for your Minikube do be able to find the Helm package that you are about to build and export, you need to point your machine's Docker Engine to use Minikube's instead (once you've started your Minikube cluster). 
+Minikube uses its own Docker Engine, not your machine's Docker Engine. Habitat Studio uses your machine's Docker Engine. So, in order for your Minikube to be able to find the Helm package that you are about to build and export, you need to point your machine's Docker Engine to use Minikube's instead (once you've started your Minikube cluster).
 
 So, for the purposes of this Helm demo to work locally, you now need to do: 
 

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -28,6 +28,7 @@ And now, let's get started!
 * Habitat Operator for Kubernetes: 
 
 ```
+go get -u github.com/kinvolk/habitat-operator/cmd/habitat-operator
 git clone https://github.com/kinvolk/habitat-operator.git
 cd habitat-operator
 make build

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -22,21 +22,8 @@ And now, let's get started!
 * Habitat (`brew install habitat`) (check with `hab --version` to make sure you're on 0.54.0) Or, if you prefer the `curl | bash`, try `curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash`
 * Minikube [https://kubernetes.io/docs/tasks/tools/install-minikube/](https://kubernetes.io/docs/tasks/tools/install-minikube/) 
 * Kubectl (`brew install kubectl`) Alternate installation instructions available [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-* Go (`brew install golang`) Alternate installation instructions available [here](https://golang.org/doc/install#install) 
 * Helm (`brew install kubernetes-helm`) Additional information is available on their github repo at [https://github.com/kubernetes/helm](https://github.com/kubernetes/helm), and learn how to get started at [https://docs.helm.sh/using_helm/#quickstart-guide](https://docs.helm.sh/using_helm/#quickstart-guide)
 * Tiller [https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller](https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller) (i.e. just type `helm init`) 
-* Habitat Operator for Kubernetes: 
-
-```
-go get -u github.com/kinvolk/habitat-operator/cmd/habitat-operator
-git clone https://github.com/kinvolk/habitat-operator.git
-cd habitat-operator
-make build
-make image
-```
-
-This will produce a `kinvolk/habitat-operator` image, which can then be deployed to your cluster.
-Read all about the Operator on Github at [https://github.com/kinvolk/habitat-operator/blob/master/README.md](https://github.com/kinvolk/habitat-operator/blob/master/README.md) 
 
 **Important Note** 
 
@@ -44,7 +31,6 @@ Minikube uses its own Docker Engine, not your machine's Docker Engine. Habitat S
 
 So, for the purposes of this Helm demo to work locally, you now need to do: 
 
-* Be in the same directory as your compiled habitat-operator (i.e. habitat-operator)
 * Start minikube with RBAC enabled: `minikube start --extra-config=apiserver.Authorization.Mode=RBAC` 
 * Tell your machine's Docker daemon to use minikube's instead: `eval $(minikube docker-env)`
 
@@ -62,14 +48,11 @@ Once you've cloned core-plans locally, go to `core-plans/nginx` and enter the Ha
 * Exit the Habitat Studio: `exit`
 
 You now have a Helm chart for core-plans/nginx in your core-plans/nginx/nginx-<version>-<datestamp>/ directory
-I suggest you pwd for the above ^^ so you can use it in another tab when you have started your cluster and want to know where your helm chart lives
 
 ### Start a cluster and deploy your helm chart!
 
-Here we are going to set up your minikube, and then deploy our helm chart onto that cluster. So, go back to your `habitat-operator` directory where you left your minikube cluster running and: 
+Here we are going to set up your minikube, and then deploy our helm chart onto that cluster.
 
-* `kubectl create -f examples/rbac` This gives the Habitat Operator the permissions it needs on your RBAC-enabled cluster
-* `kubectl apply -f examples/rbac/habitat-operator.yml` Deploys the Habitat Operator in your minikube cluster 
 * `kubectl -n kube-system create sa tiller` Creates a service account for Tiller in the kube-system namespace
 * `kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller` Creates a ClusterRoleBinding for Tiller
 * `helm init --service-account tiller` Installs Tiller, specifying new service account 

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -23,7 +23,6 @@ And now, let's get started!
 * Minikube [https://kubernetes.io/docs/tasks/tools/install-minikube/](https://kubernetes.io/docs/tasks/tools/install-minikube/) 
 * Kubectl (`brew install kubectl`) Alternate installation instructions available [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * Helm (`brew install kubernetes-helm`) Additional information is available on their github repo at [https://github.com/kubernetes/helm](https://github.com/kubernetes/helm), and learn how to get started at [https://docs.helm.sh/using_helm/#quickstart-guide](https://docs.helm.sh/using_helm/#quickstart-guide)
-* Tiller [https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller](https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller) (i.e. just type `helm init`) 
 
 **Important Note** 
 

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -44,7 +44,14 @@ Once you've cloned core-plans locally, go to `core-plans/nginx` and enter the Ha
 
 * Enter the Habitat Studio within the nginx core plan with `hab studio enter`
 * Build the latest nginx package and stores it as a habitat artifact (“hart”) in the nginx plan’s `results` directory: `build`
-* Export the hab artifact to a Helm chart: `hab pkg export helm results/<yourfilename>.hart` This command will look very similar to `hab pkg export helm results/tdrew-nginx-1.11.10-20180221053714-x86_64-linux.hart`
+* Export the hab artifact to a Helm chart:
+
+`hab pkg export helm results/<yourfilename>.hart`
+
+This command will look very similar to
+
+`hab pkg export helm results/tdrew-nginx-1.11.10-20180221053714-x86_64-linux.hart`
+
 * Exit the Habitat Studio: `exit`
 
 You now have a Helm chart for core-plans/nginx in your core-plans/nginx/nginx-<version>-<datestamp>/ directory

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -64,8 +64,9 @@ Here we are going to set up Helm in your Kubernetes cluster, and then deploy our
 * `helm init --service-account tiller` Installs Tiller, specifying new service account 
 * `helm version` Check and make sure you have the right version of helm running on your client & server side, (as of printing, v 2.8.1) 
 * `kubectl -n kube-system describe deploy/tiller-deploy` Check and see your service account has been correctly set up per instructions
-* `helm dependency build <what your pwd was from building your Helm + Habitat package>` Reads your new nginx-<version>-<timestamp>/requirements.yaml file and sees the dependency on the habitat-operator. Pulls down the chart that describes the Habitat Operator and embeds it in your application’s chart 
-* `helm install /Users/tdrew/core-plans/nginx/results/nginx-1.11.10-20180220023948/` (or whatever your pwd was -- if it's exactly this we need to talk.) Has Helm install your Habitat Helm package on your Minikube cluster
+* `helm repo add habitat-operator https://kinvolk.github.io/habitat-operator/helm/charts/stable/` Adds the Habitat Operator Helm repository to your Helm configuratio
+* `helm dependency update /Users/tdrew/core-plans/nginx/results/nginx-1.11.10-20180220023948/` (or whatever your pwd was -- if it's exactly this we need to talk.) Reads your new nginx-<version>-<timestamp>/requirements.yaml file and sees the dependency on the habitat-operator. Pulls down the chart that describes the Habitat Operator and embeds it in your application’s chart
+* `helm install /Users/tdrew/core-plans/nginx/results/nginx-1.11.10-20180220023948/` Has Helm install your Habitat Helm package on your Minikube cluster
 
 You will now see output similar to this: 
 

--- a/www/source/blog/2018-02-21-Habitat-Helm.html.md
+++ b/www/source/blog/2018-02-21-Habitat-Helm.html.md
@@ -58,7 +58,7 @@ You now have a Helm chart for core-plans/nginx in your core-plans/nginx/nginx-<v
 
 ### Start a cluster and deploy your helm chart!
 
-Here we are going to set up your minikube, and then deploy our helm chart onto that cluster.
+Here we are going to set up Helm in your Kubernetes cluster, and then deploy our Helm chart onto that cluster.
 
 * `kubectl -n kube-system create sa tiller` Creates a service account for Tiller in the kube-system namespace
 * `kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller` Creates a ClusterRoleBinding for Tiller


### PR DESCRIPTION
I'm not so sure of the second post, it removes the step of `helm dep build` but introduces the step of `helm init -c` (i-e two invocations of `helm init` in the same doc). We could avoid that if we move the instructions for setting up helm before exporter command but that's a big change and I'm not sure if Chef folks will be good with that.