### PR TITLE
pkg-export-helm: Add dep on `helm` package

### DIFF
--- a/components/pkg-export-helm/plan.sh
+++ b/components/pkg-export-helm/plan.sh
@@ -4,7 +4,7 @@ pkg_origin=core
 pkg_version=$(cat "$PLAN_CONTEXT/../../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/docker)
+pkg_deps=(core/docker core/helm)
 pkg_build_deps=(
   core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
   core/openssl-musl core/libsodium-musl


### PR DESCRIPTION
This would allow the exporter to be able to launch the `helm dep up` command from the Habitat studio environment, when user passes the `--download-deps` option.

The logical next step after https://github.com/kinvolk/core-plans/pull/1