### PR TITLE
pkg-export-k8s: Simplify service bind handling

### DIFF
--- a/components/pkg-export-helm/src/chart.rs
+++ b/components/pkg-export-helm/src/chart.rs
@@ -68,7 +68,8 @@ impl<'a> Chart<'a> {
         deps: Deps,
         ui: &'a mut UI,
     ) -> Self {
-        let main = json!({
+        let mut manifest_template = ManifestJson {
+            value: json!({
             "metadata_name": "{{.Values.metadataName}}",
             "service_name": "{{.Values.serviceName}}",
             "image": "{{.Values.imageName}}",
@@ -81,8 +82,8 @@ impl<'a> Chart<'a> {
             "ring_secret_name": manifest.ring_secret_name
                 .clone()
                 .map(|_| "{{.Values.ringSecretName}}"),
-            "bind": !manifest.binds.is_empty(),
-        });
+        }),
+        };
 
         let mut values = Values::new();
         values.add_entry("metadataName", &manifest.metadata_name);
@@ -120,19 +121,15 @@ impl<'a> Chart<'a> {
 
             binds.push(json);
         }
-
-        let manifest_template = Some(ManifestJson {
-            main: main,
-            binds: binds,
-        });
+        manifest_template.value["binds"] = json!(binds);
 
         Chart {
-            chartdir,
-            chartfile,
-            manifest_template,
-            values,
-            deps,
-            ui,
+            chartdir: chartdir,
+            chartfile: chartfile,
+            manifest_template: Some(manifest_template),
+            values: values,
+            deps: deps,
+            ui: ui,
         }
     }
 

--- a/components/pkg-export-kubernetes/defaults/KubernetesBind.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesBind.hbs
@@ -1,6 +1,0 @@
-      # Name is the name of the bind specified in the Habitat configuration files.
-      - name: {{name}}
-        # Service is the name of the service this bind refers to.
-        service: {{service}}
-        # Group is the group of the service this bind refers to.
-        group: {{group}}

--- a/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
+++ b/components/pkg-export-kubernetes/defaults/KubernetesManifest.hbs
@@ -42,6 +42,14 @@ spec:
     ## encrypts the communication between Habitat supervisors.
     ringSecretName: {{ring_secret_name}}
 {{~ /if ~}}
-{{~ #if bind}}
+{{~ #if binds}}
     bind:
+{{~ #each binds}}
+      # Name is the name of the bind specified in the Habitat configuration files.
+      - name: {{this.name}}
+        # Service is the name of the service this bind refers to.
+        service: {{this.service}}
+        # Group is the group of the service this bind refers to.
+        group: {{this.group}}
+{{~ /each ~}}
 {{~ /if ~}}

--- a/components/pkg-export-kubernetes/src/service_bind.rs
+++ b/components/pkg-export-kubernetes/src/service_bind.rs
@@ -15,6 +15,7 @@
 use std::str::FromStr;
 use std::result;
 use clap::ArgMatches;
+use serde_json;
 
 use export_docker::Result;
 use hcore::service::ServiceGroup;
@@ -40,6 +41,14 @@ impl ServiceBind {
         };
 
         Ok(binds)
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({
+            "name": self.name,
+            "service": self.service_group.service(),
+            "group": self.service_group.group(),
+        })
     }
 }
 


### PR DESCRIPTION
Make use of Handlebars's `each` helper to reduce complexity in the Rust
code.