### PR TITLE
Don't use Helm's dependencies feature

### DIFF
--- a/components/pkg-export-helm/src/deps.rs
+++ b/components/pkg-export-helm/src/deps.rs
@@ -47,7 +47,13 @@ impl Deps {
     }
 
     pub fn generate(&mut self, write: &mut Write) -> Result<()> {
-        let out = self.into_string()?;
+        // TODO: Until this Helm issue is resolved or has a decent workaround, let's skip the
+        //       operator dependency:
+        //
+        //       https://github.com/kubernetes/helm/issues/3632
+        //
+        //let out = self.into_string()?;
+        let out = String::new();
         write.write(out.as_bytes())?;
 
         Ok(())
@@ -89,6 +95,7 @@ impl Deps {
     }
 
     // TODO: Implement TryInto trait instead when it's in stable std crate
+    #[allow(dead_code)]
     fn into_string(&self) -> Result<String> {
         let json = json!({
             "operator_version": self.operator_version,

--- a/components/pkg-export-helm/src/deps.rs
+++ b/components/pkg-export-helm/src/deps.rs
@@ -24,8 +24,8 @@ use export_docker::Result;
 use error::Error;
 
 pub const DEFAULT_OPERATOR_VERSION: &'static str = "0.5.1";
-pub const OPERATOR_REPO_URL: &'static str = "https://kinvolk.github.io/habitat-operator\
-                                             /helm/charts/stable/";
+pub const OPERATOR_REPO_URL: &'static str = "https://habitat-sh.github.io/\
+                                             habitat-operator/helm/charts/stable/";
 
 // Helm requirements.yaml template
 const DEPSFILE: &'static str = include_str!("../defaults/HelmDeps.hbs");


### PR DESCRIPTION
Until the Helm [bug](https://github.com/kubernetes/helm/issues/3632) to handle dependencies properly is resolved, let's not use the dependencies feature and ask users to install habitat-operator chart themselves.
